### PR TITLE
Related to: https://github.com/Sanyam-G/switch/issues/8

### DIFF
--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -73,10 +73,10 @@ enum WindowEnumerator {
         for w in candidates {
             if pidsScanned.contains(w.pid) { continue }
             pidsScanned.insert(w.pid)
-            let appAX = AXUIElementCreateApplication(w.pid)
-            var ref: CFTypeRef?
-            guard AXUIElementCopyAttributeValue(appAX, kAXWindowsAttribute as CFString, &ref) == .success,
-                  let axWindows = ref as? [AXUIElement] else { continue }
+            // AXHelpers.allWindows tries "AXAllWindows" first, which returns windows
+            // across all Spaces. Falling back to kAXWindowsAttribute (current Space
+            // only) would incorrectly drop windows living on other Spaces.
+            let axWindows = AXHelpers.allWindows(for: w.pid)
             for ax in axWindows {
                 var id: CGWindowID = 0
                 if _AXUIElementGetWindow(ax, &id) == .success, id != 0 {

--- a/Sources/Switch/WindowFocuser.swift
+++ b/Sources/Switch/WindowFocuser.swift
@@ -25,11 +25,8 @@ enum WindowFocuser {
         let app = NSRunningApplication(processIdentifier: window.pid)
         if app?.isHidden == true { app?.unhide() }
 
-        let appAX = AXUIElementCreateApplication(window.pid)
-        var ref: CFTypeRef?
-        if AXUIElementCopyAttributeValue(appAX, kAXWindowsAttribute as CFString, &ref) == .success,
-           let axWindows = ref as? [AXUIElement],
-           let target = bestMatch(for: window, in: axWindows) ?? axWindows.first {
+        let axWindows = AXHelpers.allWindows(for: window.pid)
+        if let target = bestMatch(for: window, in: axWindows) ?? axWindows.first {
             AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
             AXUIElementPerformAction(target, kAXRaiseAction as CFString)
         }
@@ -72,10 +69,8 @@ enum AppCloser {
 enum WindowCloser {
     /// Sends a close action to the AX window matching `window`. Best-effort.
     static func close(_ window: WindowInfo) {
-        let appAX = AXUIElementCreateApplication(window.pid)
-        var ref: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(appAX, kAXWindowsAttribute as CFString, &ref) == .success,
-              let axWindows = ref as? [AXUIElement] else { return }
+        let axWindows = AXHelpers.allWindows(for: window.pid)
+        guard !axWindows.isEmpty else { return }
 
         // Direct CGWindowID match via private SPI, same as focus. Title
         // matching alone closed the wrong Chrome window when titles collided.
@@ -93,6 +88,22 @@ enum WindowCloser {
 }
 
 enum AXHelpers {
+    /// Returns all AX windows for `pid` across every Space.
+    /// Tries "AXAllWindows" first (cross-Space capable); falls back to
+    /// kAXWindowsAttribute (current-Space only) for apps that don't support it.
+    /// Ghost/orderOut'd windows are absent from both attributes, so the
+    /// ghost-removal behaviour elsewhere in the codebase is preserved.
+    static func allWindows(for pid: pid_t) -> [AXUIElement] {
+        let appAX = AXUIElementCreateApplication(pid)
+        var ref: CFTypeRef?
+        if AXUIElementCopyAttributeValue(appAX, "AXAllWindows" as CFString, &ref) == .success,
+           let windows = ref as? [AXUIElement] {
+            return windows
+        }
+        AXUIElementCopyAttributeValue(appAX, kAXWindowsAttribute as CFString, &ref)
+        return ref as? [AXUIElement] ?? []
+    }
+
     static func title(of element: AXUIElement) -> String {
         var ref: CFTypeRef?
         AXUIElementCopyAttributeValue(element, kAXTitleAttribute as CFString, &ref)


### PR DESCRIPTION
https://github.com/Sanyam-G/switch/issues/8

What was changed
Root cause: kAXWindowsAttribute ("AXWindows") only returns windows on the currently active Space. This caused three breakages: 1.
filterAXVisible in WindowEnumerator.swift — windows on other spaces (including active spaces on other monitors) were fed through this filter, kAXWindowsAttribute didn't find them, so they were silently dropped from the picker entirely. 2.
WindowFocuser.focus — when switching to a cross-space window, the AX lookup would miss it and fall back to axWindows.first, potentially focusing the wrong window. 3.
WindowCloser.close — same AX lookup issue when trying to close a cross-space window. Fix: Added AXHelpers.allWindows(for:) which tries "AXAllWindows" first. This is the attribute used by AltTab and other third-party window managers — it returns all windows across every Space. Ghost/orderOut'd windows (the SwiftUI Settings panels the original filter was designed to catch) are absent from "AXAllWindows" as well, so that protection is still intact. Falls back to kAXWindowsAttribute for any app that doesn't support the broader attribute. All three call sites now go through this single helper.