### PR TITLE
Multiple shortcuts per action

### DIFF
--- a/Sources/Switch/HotkeyConfig.swift
+++ b/Sources/Switch/HotkeyConfig.swift
@@ -11,6 +11,11 @@ struct HotkeyBinding: Codable, Equatable {
 
     var cgFlags: CGEventFlags { CGEventFlags(rawValue: modifiersRaw) }
 
+    /// Empty placeholder used while the user is recording a new row in Settings.
+    var isEmpty: Bool { keyCode == 0 && modifiersRaw == 0 }
+
+    static let empty = HotkeyBinding(keyCode: 0, modifiersRaw: 0)
+
     static let defaultAllWindows = HotkeyBinding(
         keyCode: 48, // Tab
         modifiersRaw: CGEventFlags.maskCommand.rawValue
@@ -55,7 +60,9 @@ struct HotkeyBinding: Codable, Equatable {
     }
 }
 
-/// Persistent config for the arming hotkeys.
+/// Persistent config for the arming hotkeys. Each action holds a list of bindings —
+/// every binding in the list triggers the same action. Reads are served from a
+/// lock-guarded cache so the event tap thread never touches UserDefaults.
 final class HotkeyConfig {
     static let shared = HotkeyConfig()
 
@@ -67,80 +74,96 @@ final class HotkeyConfig {
     private let seededKey = "switch.hotkey.seeded"
 
     private let lock = NSLock()
-    private var cachedAll: HotkeyBinding?
-    private var cachedApp: HotkeyBinding?
-    private var cachedSpaces: HotkeyBinding?
-    private var cachedSticky: HotkeyBinding?
+    private var cachedAll: [HotkeyBinding] = []
+    private var cachedApp: [HotkeyBinding] = []
+    private var cachedSpaces: [HotkeyBinding] = []
+    private var cachedSticky: [HotkeyBinding] = []
 
     static let didChangeNotification = Notification.Name("com.sanyamgarg.switch.hotkeyConfigDidChange")
 
-    // Seed the three arming hotkeys once so a fresh install gets defaults; after that nil means disabled.
+    // Seed each action's defaults once so a fresh install gets its defaults; after
+    // that an empty list means the user deliberately cleared the action (disabled).
     private init() {
         if !defaults.bool(forKey: seededKey) {
-            if load(allKey) == nil { write(.defaultAllWindows, key: allKey) }
-            if load(appKey) == nil { write(.defaultCurrentApp, key: appKey) }
+            if loadList(allKey) == nil { writeList([.defaultAllWindows], key: allKey) }
+            if loadList(appKey) == nil { writeList([.defaultCurrentApp], key: appKey) }
             // Spaces ships unbound; ⌃Tab would swallow browser tab switching (#91). Opt in via Settings.
             defaults.set(true, forKey: seededKey)
         }
-        cachedAll = load(allKey)
-        cachedApp = load(appKey)
-        cachedSpaces = load(spacesKey)
-        cachedSticky = load(stickyKey)
+        cachedAll = loadList(allKey) ?? []
+        cachedApp = loadList(appKey) ?? []
+        cachedSpaces = loadList(spacesKey) ?? []
+        cachedSticky = loadList(stickyKey) ?? []
     }
 
-    var allWindows: HotkeyBinding? {
+    // MARK: - List accessors (canonical)
+    // An empty list means the action is disabled — seeding guarantees a fresh
+    // install still gets its defaults, so empty here is a deliberate clear.
+
+    var allWindowsBindings: [HotkeyBinding] {
         get { lock.lock(); defer { lock.unlock() }; return cachedAll }
-        set { store(newValue, key: allKey) { self.cachedAll = newValue } }
+        set { saveList(newValue, key: allKey) { self.cachedAll = $0 } }
     }
 
-    var currentApp: HotkeyBinding? {
+    var currentAppBindings: [HotkeyBinding] {
         get { lock.lock(); defer { lock.unlock() }; return cachedApp }
-        set { store(newValue, key: appKey) { self.cachedApp = newValue } }
+        set { saveList(newValue, key: appKey) { self.cachedApp = $0 } }
     }
 
-    var spaces: HotkeyBinding? {
+    var spacesBindings: [HotkeyBinding] {
         get { lock.lock(); defer { lock.unlock() }; return cachedSpaces }
-        set { store(newValue, key: spacesKey) { self.cachedSpaces = newValue } }
+        set { saveList(newValue, key: spacesKey) { self.cachedSpaces = $0 } }
     }
 
-    var stickyToggle: HotkeyBinding? {
+    var stickyToggleBindings: [HotkeyBinding] {
         get { lock.lock(); defer { lock.unlock() }; return cachedSticky }
-        set { store(newValue, key: stickyKey) { self.cachedSticky = newValue } }
+        set { saveList(newValue, key: stickyKey) { self.cachedSticky = $0 } }
     }
 
     func resetToDefaults() {
-        write(.defaultAllWindows, key: allKey)
-        write(.defaultCurrentApp, key: appKey)
+        writeList([.defaultAllWindows], key: allKey)
+        writeList([.defaultCurrentApp], key: appKey)
         defaults.removeObject(forKey: spacesKey)
         defaults.removeObject(forKey: stickyKey)
+        defaults.set(true, forKey: seededKey)
         lock.lock()
-        cachedAll = .defaultAllWindows
-        cachedApp = .defaultCurrentApp
-        cachedSpaces = nil
-        cachedSticky = nil
+        cachedAll = [.defaultAllWindows]
+        cachedApp = [.defaultCurrentApp]
+        cachedSpaces = []
+        cachedSticky = []
         lock.unlock()
         NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
     }
 
-    private func load(_ key: String) -> HotkeyBinding? {
+    /// Decode array first; fall back to legacy single-binding payload and wrap.
+    private func loadList(_ key: String) -> [HotkeyBinding]? {
         guard let data = defaults.data(forKey: key) else { return nil }
-        return try? JSONDecoder().decode(HotkeyBinding.self, from: data)
+        if let arr = try? JSONDecoder().decode([HotkeyBinding].self, from: data) {
+            return arr.filter { !$0.isEmpty }
+        }
+        if let one = try? JSONDecoder().decode(HotkeyBinding.self, from: data), !one.isEmpty {
+            return [one]
+        }
+        return nil
     }
 
-    private func store(_ b: HotkeyBinding?, key: String, updateCache: () -> Void) {
-        if let b, let data = try? JSONEncoder().encode(b) {
-            defaults.set(data, forKey: key)
-        } else {
+    private func saveList(_ list: [HotkeyBinding], key: String, updateCache: ([HotkeyBinding]) -> Void) {
+        let cleaned = list.filter { !$0.isEmpty }
+        if cleaned.isEmpty {
             defaults.removeObject(forKey: key)
+        } else if let data = try? JSONEncoder().encode(cleaned) {
+            defaults.set(data, forKey: key)
         }
         lock.lock()
-        updateCache()
+        updateCache(cleaned)
         lock.unlock()
         NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
     }
 
-    private func write(_ b: HotkeyBinding, key: String) {
-        if let data = try? JSONEncoder().encode(b) { defaults.set(data, forKey: key) }
+    /// Persist without posting a change notification — used for one-time seeding
+    /// and reset, where listeners reload through their own paths.
+    private func writeList(_ list: [HotkeyBinding], key: String) {
+        if let data = try? JSONEncoder().encode(list) { defaults.set(data, forKey: key) }
     }
 }
 
@@ -170,6 +193,17 @@ enum HotkeyValidator {
             return "That combo is reserved by macOS or common apps."
         }
         return nil
+    }
+
+    /// Reject if the same combo (modulo shift) already appears in `existing`.
+    /// Shift is ignored — matchesTrigger ignores it anyway, so two bindings that
+    /// differ only by shift would behave identically.
+    static func duplicate(of candidate: HotkeyBinding, in existing: [HotkeyBinding]) -> Bool {
+        let mask: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl]
+        let cFlags = candidate.cgFlags.intersection(mask)
+        return existing.contains { b in
+            b.keyCode == candidate.keyCode && b.cgFlags.intersection(mask) == cFlags
+        }
     }
 }
 

--- a/Sources/Switch/HotkeyManager.swift
+++ b/Sources/Switch/HotkeyManager.swift
@@ -25,6 +25,10 @@ final class HotkeyManager {
     private var tap: CFMachPort?
     private var source: CFRunLoopSource?
     private var armed: Mode?
+    /// The specific binding that armed the picker. When that binding's modifiers
+    /// drop (flagsChanged), we commit — independent of whatever other bindings
+    /// the user has configured for the same action.
+    private var armedBinding: HotkeyBinding?
     private var armedAt: Date?
     private var advanced = false
     private var lastShift = false
@@ -224,28 +228,28 @@ final class HotkeyManager {
         let kc = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
 
         if type == .keyDown {
-            let allBinding = HotkeyConfig.shared.allWindows
-            let appBinding = HotkeyConfig.shared.currentApp
-            let spacesBinding = HotkeyConfig.shared.spaces
+            let allBindings = HotkeyConfig.shared.allWindowsBindings
+            let appBindings = HotkeyConfig.shared.currentAppBindings
+            let spacesBindings = HotkeyConfig.shared.spacesBindings
+            let stickyBindings = HotkeyConfig.shared.stickyToggleBindings
 
-            if let stickyBinding = HotkeyConfig.shared.stickyToggle,
-               stickyBinding.matchesTrigger(keyCode: kc, flags: flags) {
+            if stickyBindings.contains(where: { $0.matchesTrigger(keyCode: kc, flags: flags) }) {
                 DispatchQueue.main.async { [weak self] in
                     self?.onStickyToggle?()
                 }
                 return nil
             }
 
-            if let allBinding, allBinding.matchesTrigger(keyCode: kc, flags: flags) {
-                armOrAdvance(.allWindows, shift: shift)
+            if let matched = allBindings.first(where: { $0.matchesTrigger(keyCode: kc, flags: flags) }) {
+                armOrAdvance(.allWindows, binding: matched, shift: shift)
                 return nil
             }
-            if let spacesBinding, spacesBinding.matchesTrigger(keyCode: kc, flags: flags) {
-                armOrAdvance(.spaces, shift: shift)
+            if let matched = spacesBindings.first(where: { $0.matchesTrigger(keyCode: kc, flags: flags) }) {
+                armOrAdvance(.spaces, binding: matched, shift: shift)
                 return nil
             }
-            if let appBinding, appBinding.matchesTrigger(keyCode: kc, flags: flags) {
-                armOrAdvance(.currentApp, shift: shift)
+            if let matched = appBindings.first(where: { $0.matchesTrigger(keyCode: kc, flags: flags) }) {
+                armOrAdvance(.currentApp, binding: matched, shift: shift)
                 return nil
             }
 
@@ -253,7 +257,7 @@ final class HotkeyManager {
             let armedMode = armed
             stateLock.unlock()
 
-            if let mode = armedMode {
+            if armedMode != nil {
                 let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
                 let typeToFilter = (UserDefaults.standard.object(forKey: SwitchPreferences.typeToFilterKey) as? Bool) ?? true
                 let actionModifierMatches = cmd && (sticky || !typeToFilter || shift)
@@ -271,7 +275,7 @@ final class HotkeyManager {
                     }
                     return nil
                 }
-                if !sticky && !armingModifiersHeld(mode, flags) {
+                if !sticky && !armedBindingModifiersHeld(flags) {
                     clearArmed()
                     DispatchQueue.main.async { [weak self] in
                         self?.onCommit?()
@@ -302,7 +306,7 @@ final class HotkeyManager {
                     }
                     return nil
                 }
-                if kc == Self.kcComma && (cmd || armingModifiersHeld(mode, flags)) {
+                if kc == Self.kcComma && (cmd || armedBindingModifiersHeld(flags)) {
                     clearArmed()
                     DispatchQueue.main.async { [weak self] in
                         self?.onCancel?()
@@ -337,12 +341,13 @@ final class HotkeyManager {
             stateLock.lock()
             let shiftRising = shift && !lastShift
             lastShift = shift
-            guard let mode = armed else {
+            guard let armedBinding else {
                 stateLock.unlock()
                 return Unmanaged.passUnretained(event)
             }
-            let armingHeld = armingModifiersHeld(mode, flags)
+            let armingHeld = armedBinding.modifiersHeld(flags)
 
+            // Tap shift while still holding the arming combo to step backward.
             if shiftRising && armingHeld
                 && UserDefaults.standard.bool(forKey: SwitchPreferences.shiftTapReversesKey) {
                 advanced = true
@@ -353,6 +358,8 @@ final class HotkeyManager {
                 return nil
             }
 
+            // Releasing the arming binding's modifiers commits — independent of any
+            // other binding configured for the same action.
             if !armingHeld {
                 let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
                 let quickTap = (armedAt.map { Date().timeIntervalSince($0) * 1000 < Self.stickyQuickTapMS } ?? false) && !advanced
@@ -372,11 +379,12 @@ final class HotkeyManager {
         return Unmanaged.passUnretained(event)
     }
 
-    private func armOrAdvance(_ mode: Mode, shift: Bool) {
+    private func armOrAdvance(_ mode: Mode, binding: HotkeyBinding, shift: Bool) {
         stateLock.lock()
         let isFirst = armed == nil
         if isFirst {
             armed = mode
+            armedBinding = binding
             armedAt = Date()
             advanced = false
         } else {
@@ -388,13 +396,12 @@ final class HotkeyManager {
         }
     }
 
-    private func armingModifiersHeld(_ mode: Mode, _ flags: CGEventFlags) -> Bool {
-        let binding: HotkeyBinding?
-        switch mode {
-        case .allWindows: binding = HotkeyConfig.shared.allWindows
-        case .currentApp: binding = HotkeyConfig.shared.currentApp
-        case .spaces:     binding = HotkeyConfig.shared.spaces
-        }
+    /// Whether the modifiers of the binding that armed the picker are still held —
+    /// independent of any other binding configured for the same action.
+    private func armedBindingModifiersHeld(_ flags: CGEventFlags) -> Bool {
+        stateLock.lock()
+        let binding = armedBinding
+        stateLock.unlock()
         return binding?.modifiersHeld(flags) ?? false
     }
 
@@ -406,6 +413,7 @@ final class HotkeyManager {
 
     private func clearArmedLocked() {
         armed = nil
+        armedBinding = nil
         armedAt = nil
         advanced = false
     }
@@ -432,7 +440,7 @@ final class HotkeyManager {
         }
         stateLock.unlock()
         let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
-        guard !sticky, !armingModifiersHeld(mode, hardware) else { return }
+        guard !sticky, !armedBindingModifiersHeld(hardware) else { return }
         stateLock.lock()
         guard armed == mode, armedAt == at else {
             stateLock.unlock()

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -117,6 +117,16 @@ final class SettingsModel: ObservableObject {
         }
     }
 
+    /// Action that already holds a binding clashing with `b`, across all actions
+    /// (the row being edited is excluded). Nil when `b` is free.
+    func duplicateOwner(of b: HotkeyBinding, excluding id: UUID) -> HotkeyAction? {
+        for action in HotkeyAction.allCases {
+            let others = bindings(for: action).filter { $0.id != id }.map(\.binding)
+            if HotkeyValidator.duplicate(of: b, in: others) { return action }
+        }
+        return nil
+    }
+
     func resetHotkeys() {
         HotkeyConfig.shared.resetToDefaults()
         refresh()
@@ -544,7 +554,7 @@ struct SettingsView: View {
             KeyRecorderField(
                 initialBinding: row.binding,
                 onCapture: { b in
-                    apply(b, existing: model.bindings(for: action).filter { $0.id != row.id }.map(\.binding)) {
+                    apply(b, excludingRow: row.id) {
                         model.updateBinding(action, id: row.id, to: $0)
                     }
                 },
@@ -852,15 +862,15 @@ struct SettingsView: View {
         }
     }
 
-    /// Validate `b` against system-reserved combos and the user's other bindings,
-    /// then either show a reject message or hand it to `save`.
-    private func apply(_ b: HotkeyBinding, existing: [HotkeyBinding] = [], save: (HotkeyBinding) -> Void) {
+    /// Validate `b` against system-reserved combos and the user's bindings on
+    /// every action, then either show a reject message or hand it to `save`.
+    private func apply(_ b: HotkeyBinding, excludingRow id: UUID, save: (HotkeyBinding) -> Void) {
         if let msg = HotkeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags) {
             rejectMessage = msg
             return
         }
-        if HotkeyValidator.duplicate(of: b, in: existing) {
-            rejectMessage = "That combo is already bound to this action."
+        if let owner = model.duplicateOwner(of: b, excluding: id) {
+            rejectMessage = "That combo is already bound to “\(owner.label)”."
             return
         }
         rejectMessage = nil

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -98,7 +98,20 @@ final class SettingsModel: ObservableObject {
         }
     }
 
+    /// Whether this row may be removed. All windows / Current app must keep at
+    /// least one real binding — otherwise the persistence layer would drop the
+    /// defaults key and the default combo would silently come back while the UI
+    /// shows nothing. Sticky toggle stays fully optional.
+    func canRemoveBinding(_ action: HotkeyAction, id: UUID) -> Bool {
+        guard action != .stickyToggle else { return true }
+        let list = bindings(for: action)
+        guard let row = list.first(where: { $0.id == id }) else { return false }
+        if row.binding.isEmpty { return true }
+        return list.filter { !$0.binding.isEmpty }.count > 1
+    }
+
     func removeBinding(_ action: HotkeyAction, id: UUID) {
+        guard canRemoveBinding(action, id: id) else { return }
         mutate(action) { list in
             list.removeAll { $0.id == id }
         }
@@ -539,16 +552,18 @@ struct SettingsView: View {
                 placeholder: action.placeholder
             )
             .frame(width: 110, height: 24)
-            Button {
-                rejectMessage = nil
-                model.removeBinding(action, id: row.id)
-            } label: {
-                Image(systemName: "minus.circle.fill")
-                    .font(.system(size: 13))
-                    .foregroundStyle(.secondary)
+            if model.canRemoveBinding(action, id: row.id) {
+                Button {
+                    rejectMessage = nil
+                    model.removeBinding(action, id: row.id)
+                } label: {
+                    Image(systemName: "minus.circle.fill")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Remove this shortcut")
             }
-            .buttonStyle(.plain)
-            .help("Remove this shortcut")
         }
     }
 

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -8,6 +8,9 @@ import ServiceManagement
 struct EditableBinding: Identifiable, Equatable {
     let id: UUID
     var binding: HotkeyBinding
+    /// One-shot request: the recorder field for this row should start recording.
+    /// Set by "+ Add", cleared once the field has picked it up.
+    var wantsRecording: Bool = false
 
     init(_ binding: HotkeyBinding, id: UUID = UUID()) {
         self.id = id
@@ -91,10 +94,16 @@ final class SettingsModel: ObservableObject {
     }
 
     func addBinding(_ action: HotkeyAction) {
-        mutate(action) { list in
-            // Avoid appending a second empty placeholder row.
-            guard !list.contains(where: { $0.binding.isEmpty }) else { return }
-            list.append(EditableBinding(.empty))
+        // Empty rows never persist, so no need to write through to HotkeyConfig.
+        mutate(action, persisting: false) { list in
+            if let idx = list.firstIndex(where: { $0.binding.isEmpty }) {
+                // Re-arm the existing empty row instead of stacking another.
+                list[idx].wantsRecording = true
+            } else {
+                var row = EditableBinding(.empty)
+                row.wantsRecording = true
+                list.append(row)
+            }
         }
     }
 
@@ -117,6 +126,14 @@ final class SettingsModel: ObservableObject {
         }
     }
 
+    /// The recorder field picked up a `wantsRecording` request; clear the flag.
+    func consumeRecordingRequest(_ action: HotkeyAction, id: UUID) {
+        mutate(action, persisting: false) { list in
+            guard let idx = list.firstIndex(where: { $0.id == id }) else { return }
+            list[idx].wantsRecording = false
+        }
+    }
+
     /// Action that already holds a binding clashing with `b`, across all actions
     /// (the row being edited is excluded). Nil when `b` is free.
     func duplicateOwner(of b: HotkeyBinding, excluding id: UUID) -> HotkeyAction? {
@@ -132,13 +149,14 @@ final class SettingsModel: ObservableObject {
         refresh()
     }
 
-    private func mutate(_ action: HotkeyAction, _ change: (inout [EditableBinding]) -> Void) {
+    private func mutate(_ action: HotkeyAction, persisting: Bool = true, _ change: (inout [EditableBinding]) -> Void) {
         switch action {
-        case .allWindows:    change(&allWindowsBindings); persist(action)
-        case .currentApp:    change(&currentAppBindings); persist(action)
-        case .spaces:        change(&spacesBindings); persist(action)
-        case .stickyToggle:  change(&stickyToggleBindings); persist(action)
+        case .allWindows:    change(&allWindowsBindings)
+        case .currentApp:    change(&currentAppBindings)
+        case .spaces:        change(&spacesBindings)
+        case .stickyToggle:  change(&stickyToggleBindings)
         }
+        if persisting { persist(action) }
     }
 
     private func persist(_ action: HotkeyAction) {
@@ -559,7 +577,9 @@ struct SettingsView: View {
                     }
                 },
                 accent: prefs.accent.color,
-                placeholder: action.placeholder
+                placeholder: action.placeholder,
+                beginRecording: row.wantsRecording,
+                onBeginRecordingHandled: { model.consumeRecordingRequest(action, id: row.id) }
             )
             .frame(width: 110, height: 24)
             if model.canRemoveBinding(action, id: row.id) {
@@ -945,6 +965,10 @@ struct KeyRecorderField: NSViewRepresentable {
     let onCapture: (HotkeyBinding) -> Void
     var accent: Color = .accentColor
     var placeholder: String = "—"
+    /// One-shot: start recording as soon as the view is set up (used by "+ Add").
+    /// Call `onBeginRecordingHandled` to clear the flag upstream once consumed.
+    var beginRecording: Bool = false
+    var onBeginRecordingHandled: (() -> Void)? = nil
 
     func makeNSView(context: Context) -> KeyRecorderNSView {
         let v = KeyRecorderNSView()
@@ -962,6 +986,15 @@ struct KeyRecorderField: NSViewRepresentable {
         view.onCapture = onCapture
         view.accentNSColor = NSColor(accent)
         view.placeholder = placeholder
+        if beginRecording {
+            let handled = onBeginRecordingHandled
+            // Async so the view is in its window (first responder works) and we
+            // don't mutate SwiftUI state during the update pass.
+            DispatchQueue.main.async {
+                view.beginRecording()
+                handled?()
+            }
+        }
     }
 }
 
@@ -1009,6 +1042,11 @@ final class KeyRecorderNSView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         if recording { stopRecording(commit: false) } else { startRecording() }
+    }
+
+    /// Programmatic entry point for "+ Add" — no-op when already recording.
+    func beginRecording() {
+        if !recording { startRecording() }
     }
 
     override func resignFirstResponder() -> Bool {

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -3,13 +3,45 @@ import Carbon.HIToolbox
 import SwiftUI
 import ServiceManagement
 
+/// Wrapper that pairs a binding with a stable SwiftUI identity, so reordering /
+/// deleting rows doesn't reshuffle `KeyRecorderField` NSViews mid-recording.
+struct EditableBinding: Identifiable, Equatable {
+    let id: UUID
+    var binding: HotkeyBinding
+
+    init(_ binding: HotkeyBinding, id: UUID = UUID()) {
+        self.id = id
+        self.binding = binding
+    }
+}
+
+enum HotkeyAction: CaseIterable {
+    case allWindows, currentApp, spaces, stickyToggle
+
+    var label: String {
+        switch self {
+        case .allWindows:    return "All windows"
+        case .currentApp:    return "Current app"
+        case .spaces:        return "Spaces"
+        case .stickyToggle:  return "Sticky toggle"
+        }
+    }
+
+    var placeholder: String {
+        switch self {
+        case .allWindows, .currentApp, .spaces: return "—"
+        case .stickyToggle:                     return "Not set"
+        }
+    }
+}
+
 @MainActor
 final class SettingsModel: ObservableObject {
     @Published var launchAtLogin: Bool = false
-    @Published var allWindows: HotkeyBinding? = HotkeyConfig.shared.allWindows
-    @Published var currentApp: HotkeyBinding? = HotkeyConfig.shared.currentApp
-    @Published var spaces: HotkeyBinding? = HotkeyConfig.shared.spaces
-    @Published var stickyToggle: HotkeyBinding? = HotkeyConfig.shared.stickyToggle
+    @Published var allWindowsBindings: [EditableBinding] = []
+    @Published var currentAppBindings: [EditableBinding] = []
+    @Published var spacesBindings: [EditableBinding] = []
+    @Published var stickyToggleBindings: [EditableBinding] = []
 
     init() { refresh() }
 
@@ -17,10 +49,10 @@ final class SettingsModel: ObservableObject {
         if #available(macOS 13.0, *) {
             launchAtLogin = SMAppService.mainApp.status == .enabled
         }
-        allWindows = HotkeyConfig.shared.allWindows
-        currentApp = HotkeyConfig.shared.currentApp
-        spaces = HotkeyConfig.shared.spaces
-        stickyToggle = HotkeyConfig.shared.stickyToggle
+        allWindowsBindings = HotkeyConfig.shared.allWindowsBindings.map { EditableBinding($0) }
+        currentAppBindings = HotkeyConfig.shared.currentAppBindings.map { EditableBinding($0) }
+        spacesBindings = HotkeyConfig.shared.spacesBindings.map { EditableBinding($0) }
+        stickyToggleBindings = HotkeyConfig.shared.stickyToggleBindings.map { EditableBinding($0) }
     }
 
     func setLaunchAtLogin(_ enabled: Bool) {
@@ -39,29 +71,61 @@ final class SettingsModel: ObservableObject {
         }
     }
 
-    func updateAllWindows(_ b: HotkeyBinding?) {
-        HotkeyConfig.shared.allWindows = b
-        allWindows = b
+    func bindings(for action: HotkeyAction) -> [EditableBinding] {
+        switch action {
+        case .allWindows:    return allWindowsBindings
+        case .currentApp:    return currentAppBindings
+        case .spaces:        return spacesBindings
+        case .stickyToggle:  return stickyToggleBindings
+        }
     }
 
-    func updateCurrentApp(_ b: HotkeyBinding?) {
-        HotkeyConfig.shared.currentApp = b
-        currentApp = b
+    /// Replace the binding at `id` and persist. Empty (placeholder) bindings are
+    /// allowed in the in-memory list for UX (just-added empty row) but get
+    /// stripped at the persistence layer.
+    func updateBinding(_ action: HotkeyAction, id: UUID, to b: HotkeyBinding) {
+        mutate(action) { list in
+            guard let idx = list.firstIndex(where: { $0.id == id }) else { return }
+            list[idx].binding = b
+        }
     }
 
-    func updateSpaces(_ b: HotkeyBinding?) {
-        HotkeyConfig.shared.spaces = b
-        spaces = b
+    func addBinding(_ action: HotkeyAction) {
+        mutate(action) { list in
+            // Avoid appending a second empty placeholder row.
+            guard !list.contains(where: { $0.binding.isEmpty }) else { return }
+            list.append(EditableBinding(.empty))
+        }
     }
 
-    func updateStickyToggle(_ b: HotkeyBinding?) {
-        HotkeyConfig.shared.stickyToggle = b
-        stickyToggle = b
+    func removeBinding(_ action: HotkeyAction, id: UUID) {
+        mutate(action) { list in
+            list.removeAll { $0.id == id }
+        }
     }
 
     func resetHotkeys() {
         HotkeyConfig.shared.resetToDefaults()
         refresh()
+    }
+
+    private func mutate(_ action: HotkeyAction, _ change: (inout [EditableBinding]) -> Void) {
+        switch action {
+        case .allWindows:    change(&allWindowsBindings); persist(action)
+        case .currentApp:    change(&currentAppBindings); persist(action)
+        case .spaces:        change(&spacesBindings); persist(action)
+        case .stickyToggle:  change(&stickyToggleBindings); persist(action)
+        }
+    }
+
+    private func persist(_ action: HotkeyAction) {
+        let payload = bindings(for: action).map(\.binding).filter { !$0.isEmpty }
+        switch action {
+        case .allWindows:    HotkeyConfig.shared.allWindowsBindings = payload
+        case .currentApp:    HotkeyConfig.shared.currentAppBindings = payload
+        case .spaces:        HotkeyConfig.shared.spacesBindings = payload
+        case .stickyToggle:  HotkeyConfig.shared.stickyToggleBindings = payload
+        }
     }
 }
 
@@ -149,18 +213,10 @@ struct SettingsView: View {
                 }
 
                 section("Hotkeys") {
-                    VStack(alignment: .leading, spacing: 12) {
-                        hotkeyRow(label: "All windows", binding: model.allWindows) { b in
-                            applyHotkey(b) { model.updateAllWindows($0) }
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(HotkeyAction.allCases, id: \.self) { action in
+                            hotkeyActionGroup(action)
                         }
-                        hotkeyRow(label: "Current app", binding: model.currentApp) { b in
-                            applyHotkey(b) { model.updateCurrentApp($0) }
-                        }
-                        hotkeyRow(label: "Spaces", binding: model.spaces,
-                                  detail: "Cycle Spaces. Conflicts with browser tab switching if set to ⌃Tab.") { b in
-                            applyHotkey(b) { model.updateSpaces($0) }
-                        }
-                        stickyToggleRow
                         if let msg = rejectMessage {
                             Text(msg)
                                 .font(.system(size: 11))
@@ -177,7 +233,7 @@ struct SettingsView: View {
                             }
                             .controlSize(.small)
                         }
-                        .padding(.top, 4)
+                        .padding(.top, 2)
                     }
                     .padding(14)
                     .background(rowBackground)
@@ -443,23 +499,56 @@ struct SettingsView: View {
         prefs.appIconSize = SwitchPreferences.defaultAppIconSize
     }
 
-    private var stickyToggleRow: some View {
-        HStack(spacing: 12) {
-            Text("Sticky toggle")
+    private func hotkeyActionGroup(_ action: HotkeyAction) -> some View {
+        let rows = model.bindings(for: action)
+        return HStack(alignment: .top, spacing: 10) {
+            Text(action.label)
                 .font(.system(size: 13, weight: .medium))
                 .frame(width: 100, alignment: .leading)
-            KeyRecorderField(
-                initialBinding: model.stickyToggle ?? HotkeyBinding(keyCode: 0, modifiersRaw: 0),
-                onCapture: { b in apply(b) { model.updateStickyToggle($0) } },
-                accent: prefs.accent.color,
-                placeholder: "Not set"
-            )
-            .frame(width: 180, height: 28)
-            if model.stickyToggle != nil {
-                Button("Clear") { model.updateStickyToggle(nil) }
-                    .controlSize(.small)
+                .padding(.top, 4)
+            FlowLayout(spacing: 6, lineSpacing: 6) {
+                ForEach(rows) { row in
+                    hotkeyEditorRow(action: action, row: row)
+                }
+                Button {
+                    rejectMessage = nil
+                    model.addBinding(action)
+                } label: {
+                    Label("Add", systemImage: "plus.circle")
+                        .font(.system(size: 11, weight: .medium))
+                        .padding(.horizontal, 6)
+                        .frame(height: 24)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(prefs.accent.color)
             }
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func hotkeyEditorRow(action: HotkeyAction, row: EditableBinding) -> some View {
+        HStack(spacing: 4) {
+            KeyRecorderField(
+                initialBinding: row.binding,
+                onCapture: { b in
+                    apply(b, existing: model.bindings(for: action).filter { $0.id != row.id }.map(\.binding)) {
+                        model.updateBinding(action, id: row.id, to: $0)
+                    }
+                },
+                accent: prefs.accent.color,
+                placeholder: action.placeholder
+            )
+            .frame(width: 110, height: 24)
+            Button {
+                rejectMessage = nil
+                model.removeBinding(action, id: row.id)
+            } label: {
+                Image(systemName: "minus.circle.fill")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Remove this shortcut")
         }
     }
 
@@ -717,34 +806,6 @@ struct SettingsView: View {
         .background(rowBackground)
     }
 
-    private func hotkeyRow(label: String, binding: HotkeyBinding?, detail: String? = nil, onCapture: @escaping (HotkeyBinding?) -> Void) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 12) {
-                Text(label)
-                    .font(.system(size: 13, weight: .medium))
-                    .frame(width: 100, alignment: .leading)
-                KeyRecorderField(
-                    initialBinding: binding ?? HotkeyBinding(keyCode: 0, modifiersRaw: 0),
-                    onCapture: { onCapture($0) },
-                    accent: prefs.accent.color,
-                    placeholder: "Not set"
-                )
-                .frame(width: 180, height: 28)
-                if binding != nil {
-                    Button("Clear") { onCapture(nil) }
-                        .controlSize(.small)
-                }
-                Spacer()
-            }
-            if let detail {
-                Text(detail)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .padding(.leading, 112)
-            }
-        }
-    }
-
     private func accentSwatch(_ choice: SwitchPreferences.AccentChoice) -> some View {
         let active = prefs.accent == choice
         return Button {
@@ -776,27 +837,19 @@ struct SettingsView: View {
         }
     }
 
-    private func apply(_ b: HotkeyBinding, save: (HotkeyBinding) -> Void) {
+    /// Validate `b` against system-reserved combos and the user's other bindings,
+    /// then either show a reject message or hand it to `save`.
+    private func apply(_ b: HotkeyBinding, existing: [HotkeyBinding] = [], save: (HotkeyBinding) -> Void) {
         if let msg = HotkeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags) {
             rejectMessage = msg
-        } else {
-            rejectMessage = nil
-            save(b)
-        }
-    }
-
-    private func applyHotkey(_ b: HotkeyBinding?, save: (HotkeyBinding?) -> Void) {
-        guard let b else {
-            rejectMessage = nil
-            save(nil)
             return
         }
-        if let msg = HotkeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags) {
-            rejectMessage = msg
-        } else {
-            rejectMessage = nil
-            save(b)
+        if HotkeyValidator.duplicate(of: b, in: existing) {
+            rejectMessage = "That combo is already bound to this action."
+            return
         }
+        rejectMessage = nil
+        save(b)
     }
 
 }
@@ -1024,6 +1077,64 @@ final class KeyRecorderNSView: NSView {
             }
             layer?.borderColor = NSColor.separatorColor.cgColor
             layer?.backgroundColor = NSColor.controlBackgroundColor.withAlphaComponent(0.6).cgColor
+        }
+    }
+}
+
+/// Wraps children left-to-right and breaks to a new line when the next subview
+/// would overflow the proposed width. Used for hotkey-binding rows so multiple
+/// shortcuts per action sit side-by-side and wrap as needed.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
+    var lineSpacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxW = proposal.width ?? .infinity
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        var lines: [[CGSize]] = [[]]
+        var lineW: CGFloat = 0
+        for s in sizes {
+            let needed = lines[lines.count - 1].isEmpty ? s.width : lineW + spacing + s.width
+            if needed > maxW, !lines[lines.count - 1].isEmpty {
+                lines.append([s])
+                lineW = s.width
+            } else {
+                lines[lines.count - 1].append(s)
+                lineW = needed
+            }
+        }
+        var height: CGFloat = 0
+        var width: CGFloat = 0
+        for (i, line) in lines.enumerated() {
+            let h = line.map(\.height).max() ?? 0
+            let w = line.reduce(0) { $0 + $1.width } + CGFloat(max(0, line.count - 1)) * spacing
+            height += h
+            if i > 0 { height += lineSpacing }
+            width = max(width, w)
+        }
+        return CGSize(width: min(width, maxW), height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let maxW = bounds.width
+        var x = bounds.minX
+        var y = bounds.minY
+        var lineH: CGFloat = 0
+        var firstOnLine = true
+        for v in subviews {
+            let s = v.sizeThatFits(.unspecified)
+            let needed = firstOnLine ? s.width : (x - bounds.minX) + spacing + s.width
+            if needed > maxW && !firstOnLine {
+                x = bounds.minX
+                y += lineH + lineSpacing
+                lineH = 0
+                firstOnLine = true
+            }
+            if !firstOnLine { x += spacing }
+            v.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(s))
+            x += s.width
+            lineH = max(lineH, s.height)
+            firstOnLine = false
         }
     }
 }

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -29,6 +29,13 @@ enum HotkeyAction: CaseIterable {
         case .stickyToggle:  return "Sticky toggle"
         }
     }
+
+    var hint: String? {
+        switch self {
+        case .spaces: return "Cycle Spaces. Conflicts with browser tab switching if set to ⌃Tab."
+        default:      return nil
+        }
+    }
 }
 
 @MainActor
@@ -525,35 +532,43 @@ struct SettingsView: View {
 
     private func hotkeyActionGroup(_ action: HotkeyAction) -> some View {
         let rows = model.bindings(for: action)
-        return HStack(alignment: .top, spacing: 10) {
-            Text(action.label)
-                .font(.system(size: 13, weight: .medium))
-                .frame(width: 100, alignment: .leading)
-                .padding(.top, 4)
-            FlowLayout(spacing: 6, lineSpacing: 6) {
-                ForEach(rows) { row in
-                    hotkeyEditorRow(action: action, row: row)
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .top, spacing: 10) {
+                Text(action.label)
+                    .font(.system(size: 13, weight: .medium))
+                    .frame(width: 100, alignment: .leading)
+                    .padding(.top, 4)
+                FlowLayout(spacing: 6, lineSpacing: 6) {
+                    ForEach(rows) { row in
+                        hotkeyEditorRow(action: action, row: row)
+                    }
+                    if rows.isEmpty {
+                        Text("Not set")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .frame(height: 24)
+                            .padding(.trailing, 2)
+                    }
+                    Button {
+                        rejectMessage = nil
+                        model.addBinding(action)
+                    } label: {
+                        Text("+ Add")
+                            .font(.system(size: 11, weight: .medium))
+                            .padding(.horizontal, 6)
+                            .frame(height: 24)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(prefs.accent.color)
                 }
-                if rows.isEmpty {
-                    Text("Not set")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .frame(height: 24)
-                        .padding(.trailing, 2)
-                }
-                Button {
-                    rejectMessage = nil
-                    model.addBinding(action)
-                } label: {
-                    Text("+ Add")
-                        .font(.system(size: 11, weight: .medium))
-                        .padding(.horizontal, 6)
-                        .frame(height: 24)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(prefs.accent.color)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            if let hint = action.hint {
+                Text(hint)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 110)
+            }
         }
     }
 

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -29,13 +29,6 @@ enum HotkeyAction: CaseIterable {
         case .stickyToggle:  return "Sticky toggle"
         }
     }
-
-    var placeholder: String {
-        switch self {
-        case .allWindows, .currentApp, .spaces: return "—"
-        case .stickyToggle:                     return "Not set"
-        }
-    }
 }
 
 @MainActor
@@ -555,7 +548,7 @@ struct SettingsView: View {
                     rejectMessage = nil
                     model.addBinding(action)
                 } label: {
-                    Label("Add", systemImage: "plus.circle")
+                    Text("+ Add")
                         .font(.system(size: 11, weight: .medium))
                         .padding(.horizontal, 6)
                         .frame(height: 24)
@@ -577,7 +570,7 @@ struct SettingsView: View {
                     }
                 },
                 accent: prefs.accent.color,
-                placeholder: action.placeholder,
+                placeholder: "Not set",
                 beginRecording: row.wantsRecording,
                 onBeginRecordingHandled: { model.consumeRecordingRequest(action, id: row.id) }
             )
@@ -587,12 +580,13 @@ struct SettingsView: View {
                     rejectMessage = nil
                     model.removeBinding(action, id: row.id)
                 } label: {
-                    Image(systemName: "minus.circle.fill")
+                    Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 13))
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
                 .help("Remove this shortcut")
+                .accessibilityLabel("Remove shortcut")
             }
         }
     }
@@ -697,6 +691,7 @@ struct SettingsView: View {
                 } label: {
                     Text("+ Add app")
                         .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(prefs.accent.color)
                 }
                 .menuStyle(.borderlessButton)
                 .fixedSize()
@@ -729,6 +724,8 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.plain)
+            .help("Remove this app")
+            .accessibilityLabel("Remove app")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 6)
@@ -1027,11 +1024,19 @@ final class KeyRecorderNSView: NSView {
 
         label.alignment = .center
         label.font = .monospacedSystemFont(ofSize: 12, weight: .medium)
+        label.lineBreakMode = .byTruncatingTail
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
+        // Centered, but never wider than the field — long combos truncate
+        // instead of spilling past the rounded border.
+        let centerX = label.centerXAnchor.constraint(equalTo: centerXAnchor)
+        centerX.priority = .defaultHigh
         NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: centerYAnchor)
+            centerX,
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 4),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -4)
         ])
         redraw()
     }

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -100,20 +100,10 @@ final class SettingsModel: ObservableObject {
         }
     }
 
-    /// Whether this row may be removed. All windows / Current app must keep at
-    /// least one real binding — otherwise the persistence layer would drop the
-    /// defaults key and the default combo would silently come back while the UI
-    /// shows nothing. Sticky toggle stays fully optional.
-    func canRemoveBinding(_ action: HotkeyAction, id: UUID) -> Bool {
-        guard action != .stickyToggle else { return true }
-        let list = bindings(for: action)
-        guard let row = list.first(where: { $0.id == id }) else { return false }
-        if row.binding.isEmpty { return true }
-        return list.filter { !$0.binding.isEmpty }.count > 1
-    }
-
+    /// Removing every binding leaves the action disabled — the seeded defaults key
+    /// keeps an empty list from silently resurrecting the default combo, so this is
+    /// allowed for all actions (matching the clearable-hotkeys behaviour).
     func removeBinding(_ action: HotkeyAction, id: UUID) {
-        guard canRemoveBinding(action, id: id) else { return }
         mutate(action) { list in
             list.removeAll { $0.id == id }
         }
@@ -544,6 +534,13 @@ struct SettingsView: View {
                 ForEach(rows) { row in
                     hotkeyEditorRow(action: action, row: row)
                 }
+                if rows.isEmpty {
+                    Text("Not set")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .frame(height: 24)
+                        .padding(.trailing, 2)
+                }
                 Button {
                     rejectMessage = nil
                     model.addBinding(action)
@@ -575,19 +572,17 @@ struct SettingsView: View {
                 onBeginRecordingHandled: { model.consumeRecordingRequest(action, id: row.id) }
             )
             .frame(width: 110, height: 24)
-            if model.canRemoveBinding(action, id: row.id) {
-                Button {
-                    rejectMessage = nil
-                    model.removeBinding(action, id: row.id)
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-                .help("Remove this shortcut")
-                .accessibilityLabel("Remove shortcut")
+            Button {
+                rejectMessage = nil
+                model.removeBinding(action, id: row.id)
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
             }
+            .buttonStyle(.plain)
+            .help("Remove this shortcut")
+            .accessibilityLabel("Remove shortcut")
         }
     }
 


### PR DESCRIPTION
Hi @Sanyam-G,

thank you for developing this great piece of a software. Coming from AltTab your app works wayyy better. Faster and as far as my testing goes even robuster on current macOS Tahoe. Amazing work! 🙏

The only feature that I was missing is the ability to bind `CMD+Tab` & `Option+Tab` at the same time. This is mainly what this PR is for. I managed to make it work with just a handful of Claude Code promts. Maybe this is also a feature that others want or is interesting to incorporate into the official version. 🙌

Best regards,
@lukas-runge 

> ⚠️ **AI-generated — read as a sketch, not a polished patch.**
>
> This PR was written by Claude Code and only glossed over by a human who isn't a Swift developer. Treat it as one possible shape of the feature — an idea of how it could land, not an implementation that's been hardened, idiomatically Swift-reviewed, or proven against the codebase's conventions. Expect rough edges. Pick what's useful, discard what isn't.

## Summary

Today Switch lets you bind exactly one combo to each action — one for **All windows**, one for **Current app**, optionally one for **Sticky toggle**. This PR lets you bind as many as you want.

Concrete cases this unlocks:
- Keep `⌘-Tab` *and* add `⌥-Tab` (or `⌃-Space`, or `F19`, …) for **All windows** without giving up the original
- Run two different mod-key habits side-by-side without picking a favorite
- Try a new combo without losing the muscle-memory one — drop it if it doesn't stick

## What changes in the UI

Settings → General → Hotkeys gets a small redesign:

- Every action shows its current shortcut(s) on a single row, side-by-side
- A **+ Add** button at the end of each row registers another binding for that action
- A **✕** next to each binding removes just that one
- Existing single-binding settings carry over untouched — nothing to reconfigure

The recording flow itself is the same field everyone already knows: click it, press the combo.

## Behavior

- Any binding in an action's list triggers it. They're equal peers, not "primary + fallbacks."
- Modifier-release commit still works correctly: if you arm via `⌘-Tab`, releasing `⌘` commits — even if you also have `⌥-Tab` bound and `⌥` is still held.
- Duplicate combos are rejected with a short reason — both within an action and across actions.
- Actions can also be cleared entirely (shown as "Not set"), matching upstream's clearable hotkeys from v0.3.7 — each action now holds 0..N shortcuts.
- The spaces hotkey keeps its ⌃Tab browser-conflict hint from #91.
- The reserved-combo list (⌘Q, ⌘W, bare Esc, …) still applies per binding.
- Sticky toggle behaves the same; it just accepts multiple combos now.

## Notes

Implementation stays narrow: data, event tap, and the settings view (`HotkeyConfig`, `HotkeyManager`, `SettingsView`). No new top-level concepts, no schema versions — old preferences decode through the new shape transparently. Defaults and the **Reset** button are unchanged.

Rebased onto v0.3.10 `main`; the unrelated settings-window fixes that used to be part of this PR have been dropped.

## Test plan

- [ ] Open Settings, add a second shortcut to **All windows**, press it — picker arms
- [ ] Press the original `⌘-Tab` — still arms
- [ ] Remove the second shortcut — picker only responds to the remaining one
- [ ] Try binding `⌘Q` or `Esc` — rejected with a reason
- [ ] Try binding the same combo twice to the same action — rejected
- [ ] Hit **Reset** — defaults restored, extra bindings cleared
- [ ] Upgrade path: launch with an existing single-binding default, confirm it still triggers and shows up as the first row in the new list UI
