### PR TITLE
Hyperkey support, forward/backward key bindings in settings.

### DIFF
--- a/Sources/Switch/HotkeyConfig.swift
+++ b/Sources/Switch/HotkeyConfig.swift
@@ -3,13 +3,103 @@ import Carbon.HIToolbox
 import CoreGraphics
 import Foundation
 
-/// User-rebindable hotkey for arming the switcher.
+enum SidedModifierKey: String, Codable, CaseIterable, Comparable, Hashable {
+    case leftShift, rightShift
+    case leftControl, rightControl
+    case leftOption, rightOption
+    case leftCommand, rightCommand
+
+    init?(keyCode: CGKeyCode) {
+        switch keyCode {
+        case 56: self = .leftShift
+        case 60: self = .rightShift
+        case 59: self = .leftControl
+        case 62: self = .rightControl
+        case 58: self = .leftOption
+        case 61: self = .rightOption
+        case 55: self = .leftCommand
+        case 54: self = .rightCommand
+        default: return nil
+        }
+    }
+
+    var cgFlag: CGEventFlags {
+        switch self {
+        case .leftShift, .rightShift: return .maskShift
+        case .leftControl, .rightControl: return .maskControl
+        case .leftOption, .rightOption: return .maskAlternate
+        case .leftCommand, .rightCommand: return .maskCommand
+        }
+    }
+
+    var isPrimary: Bool {
+        switch self {
+        case .leftControl, .rightControl, .leftOption, .rightOption, .leftCommand, .rightCommand:
+            return true
+        case .leftShift, .rightShift:
+            return false
+        }
+    }
+
+    var isShift: Bool { cgFlag == .maskShift }
+
+    var displayString: String {
+        switch self {
+        case .leftShift: return "L⇧"
+        case .rightShift: return "R⇧"
+        case .leftControl: return "L⌃"
+        case .rightControl: return "R⌃"
+        case .leftOption: return "L⌥"
+        case .rightOption: return "R⌥"
+        case .leftCommand: return "L⌘"
+        case .rightCommand: return "R⌘"
+        }
+    }
+
+    private var displayOrder: Int {
+        switch self {
+        case .leftControl: return 0
+        case .rightControl: return 1
+        case .leftOption: return 2
+        case .rightOption: return 3
+        case .leftShift: return 4
+        case .rightShift: return 5
+        case .leftCommand: return 6
+        case .rightCommand: return 7
+        }
+    }
+
+    static func < (lhs: SidedModifierKey, rhs: SidedModifierKey) -> Bool {
+        lhs.displayOrder < rhs.displayOrder
+    }
+
+    static func flags(for modifiers: Set<SidedModifierKey>) -> CGEventFlags {
+        modifiers.reduce(into: CGEventFlags()) { flags, modifier in
+            flags.insert(modifier.cgFlag)
+        }
+    }
+
+    static func sides(matching flags: CGEventFlags) -> Set<SidedModifierKey> {
+        Set(allCases.filter { flags.contains($0.cgFlag) })
+    }
+}
+
+/// User-rebindable keyboard binding.
 struct HotkeyBinding: Codable, Equatable {
     var keyCode: UInt16
-    /// CGEventFlags raw value of the modifier mask required to trigger the hotkey.
+    /// CGEventFlags raw value of the modifier mask required for the binding.
     var modifiersRaw: UInt64
+    /// Nil means legacy/generic modifiers. Non-nil stores exact left/right modifier keys.
+    var sidedModifiers: Set<SidedModifierKey>? = nil
 
     var cgFlags: CGEventFlags { CGEventFlags(rawValue: modifiersRaw) }
+    var isEmpty: Bool { keyCode == Self.modifierOnlyKeyCode && modifiersRaw == 0 }
+    var isModifierOnly: Bool { keyCode == Self.modifierOnlyKeyCode && modifiersRaw != 0 }
+
+    static let modifierOnlyKeyCode = UInt16.max
+    static let empty = HotkeyBinding(keyCode: modifierOnlyKeyCode, modifiersRaw: 0)
+    static let allModifiers: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
+    static let primaryModifiers: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl]
 
     static let defaultAllWindows = HotkeyBinding(
         keyCode: 48, // Tab
@@ -21,36 +111,89 @@ struct HotkeyBinding: Codable, Equatable {
         modifiersRaw: CGEventFlags.maskAlternate.rawValue
     )
 
-    /// Whether `flags` contain exactly the required modifiers (ignoring shift, which is used for reverse).
-    func modifiersHeld(_ flags: CGEventFlags) -> Bool {
-        let needed = cgFlags
-        let mask: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl]
-        let needNeeded = needed.intersection(mask)
-        let havNeeded = flags.intersection(mask)
+    static let defaultAllWindowsForward = HotkeyBinding(
+        keyCode: 48, // Tab
+        modifiersRaw: 0
+    )
+
+    static let defaultAllWindowsBackward = HotkeyBinding(
+        keyCode: 48, // Tab
+        modifiersRaw: CGEventFlags.maskShift.rawValue
+    )
+
+    static let defaultCurrentAppForward = HotkeyBinding(
+        keyCode: 50, // Backtick
+        modifiersRaw: 0
+    )
+
+    static let defaultCurrentAppBackward = HotkeyBinding(
+        keyCode: 50, // Backtick
+        modifiersRaw: CGEventFlags.maskShift.rawValue
+    )
+
+    static func modifierOnly(_ flags: CGEventFlags) -> HotkeyBinding {
+        HotkeyBinding(keyCode: modifierOnlyKeyCode, modifiersRaw: flags.rawValue)
+    }
+
+    static func modifierOnly(_ modifiers: Set<SidedModifierKey>) -> HotkeyBinding {
+        HotkeyBinding(
+            keyCode: modifierOnlyKeyCode,
+            modifiersRaw: SidedModifierKey.flags(for: modifiers).rawValue,
+            sidedModifiers: modifiers
+        )
+    }
+
+    /// Whether the primary arming modifiers are still held.
+    func modifiersHeld(_ flags: CGEventFlags, activeSidedModifiers: Set<SidedModifierKey>) -> Bool {
+        if let sidedModifiers {
+            let needed = Set(sidedModifiers.filter(\.isPrimary))
+            return !needed.isEmpty && activeSidedModifiers.isSuperset(of: needed)
+        }
+        let needNeeded = cgFlags.intersection(Self.primaryModifiers)
+        let havNeeded = flags.intersection(Self.primaryModifiers)
         return havNeeded.contains(needNeeded) && needNeeded.rawValue != 0
     }
 
     /// Match a keyDown trigger: required modifiers held, no extra primary modifiers, key matches.
-    /// Shift is ignored for matching (reserved for reverse-direction nav).
-    func matchesTrigger(keyCode: CGKeyCode, flags: CGEventFlags) -> Bool {
+    /// Shift is ignored so Shift-modified summon chords still arm the same mode.
+    func matchesTrigger(keyCode: CGKeyCode, flags: CGEventFlags, activeSidedModifiers: Set<SidedModifierKey>) -> Bool {
         guard CGKeyCode(self.keyCode) == keyCode else { return false }
-        let mask: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl]
-        let needNeeded = cgFlags.intersection(mask)
-        return flags.intersection(mask) == needNeeded
+        if let sidedModifiers {
+            return sidedModifiersMatch(sidedModifiers, active: activeSidedModifiers)
+        }
+        let needed = cgFlags.intersection(Self.allModifiers)
+        if needed.contains(.maskShift) {
+            return flags.intersection(Self.allModifiers) == needed
+        }
+        return flags.intersection(Self.primaryModifiers) == needed.intersection(Self.primaryModifiers)
     }
 
     var displayString: String {
+        if let sidedModifiers {
+            let modifiers = sidedModifiers.sorted().map(\.displayString).joined()
+            if isModifierOnly || isEmpty { return modifiers }
+            return modifiers + KeyName.string(for: keyCode)
+        }
         var s = ""
         if cgFlags.contains(.maskControl) { s += "⌃" }
         if cgFlags.contains(.maskAlternate) { s += "⌥" }
         if cgFlags.contains(.maskShift) { s += "⇧" }
         if cgFlags.contains(.maskCommand) { s += "⌘" }
+        if isModifierOnly || isEmpty { return s }
         s += KeyName.string(for: keyCode)
         return s
     }
+
+    private func sidedModifiersMatch(_ required: Set<SidedModifierKey>, active: Set<SidedModifierKey>) -> Bool {
+        if required.contains(where: \.isShift) {
+            return active == required
+        }
+        let activePrimary = Set(active.filter { !$0.isShift })
+        return activePrimary == required
+    }
 }
 
-/// Persistent config for the two arming hotkeys. Singleton to allow lock-free reads from the event tap.
+/// Persistent hotkey config. Singleton to allow lock-free reads from the event tap.
 final class HotkeyConfig {
     static let shared = HotkeyConfig()
 
@@ -58,6 +201,10 @@ final class HotkeyConfig {
     private let allKey = "switch.hotkey.allWindows"
     private let appKey = "switch.hotkey.currentApp"
     private let stickyKey = "switch.hotkey.stickyToggle"
+    private let allForwardKey = "switch.hotkey.allWindows.forward"
+    private let allBackwardKey = "switch.hotkey.allWindows.backward"
+    private let appForwardKey = "switch.hotkey.currentApp.forward"
+    private let appBackwardKey = "switch.hotkey.currentApp.backward"
 
     static let didChangeNotification = Notification.Name("com.sanyamgarg.switch.hotkeyConfigDidChange")
 
@@ -85,10 +232,34 @@ final class HotkeyConfig {
         }
     }
 
+    var allWindowsForward: HotkeyBinding {
+        get { load(allForwardKey) ?? .defaultAllWindowsForward }
+        set { save(newValue, key: allForwardKey) }
+    }
+
+    var allWindowsBackward: HotkeyBinding {
+        get { load(allBackwardKey) ?? .defaultAllWindowsBackward }
+        set { save(newValue, key: allBackwardKey) }
+    }
+
+    var currentAppForward: HotkeyBinding {
+        get { load(appForwardKey) ?? .defaultCurrentAppForward }
+        set { save(newValue, key: appForwardKey) }
+    }
+
+    var currentAppBackward: HotkeyBinding {
+        get { load(appBackwardKey) ?? .defaultCurrentAppBackward }
+        set { save(newValue, key: appBackwardKey) }
+    }
+
     func resetToDefaults() {
         defaults.removeObject(forKey: allKey)
         defaults.removeObject(forKey: appKey)
         defaults.removeObject(forKey: stickyKey)
+        defaults.removeObject(forKey: allForwardKey)
+        defaults.removeObject(forKey: allBackwardKey)
+        defaults.removeObject(forKey: appForwardKey)
+        defaults.removeObject(forKey: appBackwardKey)
         NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
     }
 
@@ -129,6 +300,26 @@ enum HotkeyValidator {
         }
         for (rk, rf) in reserved where rk == keyCode && rf == cleaned {
             return "That combo is reserved by macOS or common apps."
+        }
+        return nil
+    }
+}
+
+enum NavigationKeyValidator {
+    private static let reservedKeyCodes: Set<UInt16> = [
+        53, // Esc
+        36, // Return
+        76  // Enter
+    ]
+
+    static func reject(keyCode: UInt16, flags: CGEventFlags) -> String? {
+        let mask: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
+        let cleaned = flags.intersection(mask)
+        if keyCode == HotkeyBinding.modifierOnlyKeyCode {
+            return cleaned.rawValue == 0 ? "Press a key or modifier." : nil
+        }
+        if reservedKeyCodes.contains(keyCode) {
+            return "That key is reserved while the picker is open."
         }
         return nil
     }

--- a/Sources/Switch/HotkeyManager.swift
+++ b/Sources/Switch/HotkeyManager.swift
@@ -26,6 +26,8 @@ final class HotkeyManager {
     private var armed: Mode?
     private var armedAt: Date?
     private var advanced = false
+    private var previousFlags: CGEventFlags = []
+    private var activeSidedModifiers = Set<SidedModifierKey>()
     private static let stickyQuickTapMS: Double = 200
     private var wakeToken: NSObjectProtocol?
     private var screensWakeToken: NSObjectProtocol?
@@ -147,32 +149,68 @@ final class HotkeyManager {
         let cmd = flags.contains(.maskCommand)
         let shift = flags.contains(.maskShift)
         let kc = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
+        let priorFlags = previousFlags
+        let priorSidedModifiers = activeSidedModifiers
+        if type == .flagsChanged {
+            previousFlags = flags
+            updateSidedModifiers(changedKeyCode: kc, flags: flags)
+        }
 
         if type == .keyDown {
             let allBinding = HotkeyConfig.shared.allWindows
             let appBinding = HotkeyConfig.shared.currentApp
 
             if let stickyBinding = HotkeyConfig.shared.stickyToggle,
-               stickyBinding.matchesTrigger(keyCode: kc, flags: flags) {
+               stickyBinding.matchesTrigger(keyCode: kc, flags: flags, activeSidedModifiers: activeSidedModifiers) {
                 DispatchQueue.main.async { [weak self] in
                     self?.onStickyToggle?()
                 }
                 return nil
             }
 
-            if allBinding.matchesTrigger(keyCode: kc, flags: flags) {
+            if let armed {
+                let armBinding = binding(for: armed)
+                let forwardBinding = forwardBinding(for: armed)
+                let backwardBinding = backwardBinding(for: armed)
+                if matchesNavigationKey(
+                    backwardBinding,
+                    keyCode: kc,
+                    flags: flags,
+                    activeSidedModifiers: activeSidedModifiers,
+                    armBinding: armBinding
+                ) {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.advanced = true
+                        self?.onAdvance?(true)
+                    }
+                    return nil
+                }
+                if matchesNavigationKey(
+                    forwardBinding,
+                    keyCode: kc,
+                    flags: flags,
+                    activeSidedModifiers: activeSidedModifiers,
+                    armBinding: armBinding
+                ) {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.advanced = true
+                        self?.onAdvance?(false)
+                    }
+                    return nil
+                }
+            }
+
+            if allBinding.matchesTrigger(keyCode: kc, flags: flags, activeSidedModifiers: activeSidedModifiers) {
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
                     if armed == nil { armed = .allWindows; armedAt = Date(); advanced = false; onArm?(.allWindows) }
-                    else { advanced = true; onAdvance?(shift) }
                 }
                 return nil
             }
-            if appBinding.matchesTrigger(keyCode: kc, flags: flags) {
+            if appBinding.matchesTrigger(keyCode: kc, flags: flags, activeSidedModifiers: activeSidedModifiers) {
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
                     if armed == nil { armed = .currentApp; armedAt = Date(); advanced = false; onArm?(.currentApp) }
-                    else { advanced = true; onAdvance?(shift) }
                 }
                 return nil
             }
@@ -253,14 +291,47 @@ final class HotkeyManager {
         if type == .flagsChanged {
             let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
             let quickTap = (armedAt.map { Date().timeIntervalSince($0) * 1000 < Self.stickyQuickTapMS } ?? false) && !advanced
-            if armed == .allWindows && !HotkeyConfig.shared.allWindows.modifiersHeld(flags) {
+            if let armed {
+                let armBinding = binding(for: armed)
+                let forwardBinding = forwardBinding(for: armed)
+                let backwardBinding = backwardBinding(for: armed)
+                if matchesNavigationModifier(
+                    backwardBinding,
+                    flags: flags,
+                    previousFlags: priorFlags,
+                    activeSidedModifiers: activeSidedModifiers,
+                    previousSidedModifiers: priorSidedModifiers,
+                    armBinding: armBinding
+                ) {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.advanced = true
+                        self?.onAdvance?(true)
+                    }
+                    return nil
+                }
+                if matchesNavigationModifier(
+                    forwardBinding,
+                    flags: flags,
+                    previousFlags: priorFlags,
+                    activeSidedModifiers: activeSidedModifiers,
+                    previousSidedModifiers: priorSidedModifiers,
+                    armBinding: armBinding
+                ) {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.advanced = true
+                        self?.onAdvance?(false)
+                    }
+                    return nil
+                }
+            }
+            if armed == .allWindows && !HotkeyConfig.shared.allWindows.modifiersHeld(flags, activeSidedModifiers: activeSidedModifiers) {
                 if !sticky || quickTap {
                     DispatchQueue.main.async { [weak self] in
                         self?.armed = nil
                         self?.onCommit?()
                     }
                 }
-            } else if armed == .currentApp && !HotkeyConfig.shared.currentApp.modifiersHeld(flags) {
+            } else if armed == .currentApp && !HotkeyConfig.shared.currentApp.modifiersHeld(flags, activeSidedModifiers: activeSidedModifiers) {
                 if !sticky || quickTap {
                     DispatchQueue.main.async { [weak self] in
                         self?.armed = nil
@@ -312,5 +383,114 @@ final class HotkeyManager {
 
     private func digitIndex(for kc: CGKeyCode) -> Int? {
         Self.kcDigits.firstIndex(of: kc) ?? Self.kcKeypadDigits.firstIndex(of: kc)
+    }
+
+    private func binding(for mode: Mode) -> HotkeyBinding {
+        switch mode {
+        case .allWindows: return HotkeyConfig.shared.allWindows
+        case .currentApp: return HotkeyConfig.shared.currentApp
+        }
+    }
+
+    private func forwardBinding(for mode: Mode) -> HotkeyBinding {
+        switch mode {
+        case .allWindows: return HotkeyConfig.shared.allWindowsForward
+        case .currentApp: return HotkeyConfig.shared.currentAppForward
+        }
+    }
+
+    private func backwardBinding(for mode: Mode) -> HotkeyBinding {
+        switch mode {
+        case .allWindows: return HotkeyConfig.shared.allWindowsBackward
+        case .currentApp: return HotkeyConfig.shared.currentAppBackward
+        }
+    }
+
+    private func matchesNavigationKey(
+        _ binding: HotkeyBinding,
+        keyCode: CGKeyCode,
+        flags: CGEventFlags,
+        activeSidedModifiers: Set<SidedModifierKey>,
+        armBinding: HotkeyBinding
+    ) -> Bool {
+        guard !binding.isEmpty, !binding.isModifierOnly else { return false }
+        guard CGKeyCode(binding.keyCode) == keyCode else { return false }
+        return navigationModifiersMatch(
+            binding,
+            flags: flags,
+            activeSidedModifiers: activeSidedModifiers,
+            armBinding: armBinding
+        )
+    }
+
+    private func matchesNavigationModifier(
+        _ binding: HotkeyBinding,
+        flags: CGEventFlags,
+        previousFlags: CGEventFlags,
+        activeSidedModifiers: Set<SidedModifierKey>,
+        previousSidedModifiers: Set<SidedModifierKey>,
+        armBinding: HotkeyBinding
+    ) -> Bool {
+        guard binding.isModifierOnly else { return false }
+        if let sidedModifiers = binding.sidedModifiers {
+            guard !sidedModifiers.isEmpty else { return false }
+            return navigationSidedModifiersMatch(sidedModifiers, active: activeSidedModifiers, armBinding: armBinding)
+                && !navigationSidedModifiersMatch(sidedModifiers, active: previousSidedModifiers, armBinding: armBinding)
+        }
+        let required = binding.cgFlags.intersection(HotkeyBinding.allModifiers)
+        guard required.rawValue != 0 else { return false }
+        return navigationFlagsMatch(required, flags: flags, armBinding: armBinding)
+            && !navigationFlagsMatch(required, flags: previousFlags, armBinding: armBinding)
+    }
+
+    private func navigationModifiersMatch(
+        _ binding: HotkeyBinding,
+        flags: CGEventFlags,
+        activeSidedModifiers: Set<SidedModifierKey>,
+        armBinding: HotkeyBinding
+    ) -> Bool {
+        if let sidedModifiers = binding.sidedModifiers {
+            return navigationSidedModifiersMatch(sidedModifiers, active: activeSidedModifiers, armBinding: armBinding)
+        }
+        return navigationFlagsMatch(binding.cgFlags, flags: flags, armBinding: armBinding)
+    }
+
+    private func navigationSidedModifiersMatch(
+        _ required: Set<SidedModifierKey>,
+        active: Set<SidedModifierKey>,
+        armBinding: HotkeyBinding
+    ) -> Bool {
+        let armPrimary = armPrimarySidedModifiers(armBinding)
+        let normalized = active.subtracting(armPrimary)
+        return normalized == required || active == required
+    }
+
+    private func navigationFlagsMatch(_ requiredFlags: CGEventFlags, flags: CGEventFlags, armBinding: HotkeyBinding) -> Bool {
+        let required = requiredFlags.intersection(HotkeyBinding.allModifiers)
+        let armPrimary = armBinding.cgFlags.intersection(HotkeyBinding.primaryModifiers)
+        let raw = flags.intersection(HotkeyBinding.allModifiers)
+        let normalized = raw.subtracting(armPrimary)
+        return normalized == required || raw == required.union(armPrimary)
+    }
+
+    private func armPrimarySidedModifiers(_ armBinding: HotkeyBinding) -> Set<SidedModifierKey> {
+        if let sidedModifiers = armBinding.sidedModifiers {
+            return Set(sidedModifiers.filter(\.isPrimary))
+        }
+        let primaryFlags = armBinding.cgFlags.intersection(HotkeyBinding.primaryModifiers)
+        return SidedModifierKey.sides(matching: primaryFlags)
+    }
+
+    private func updateSidedModifiers(changedKeyCode: CGKeyCode, flags: CGEventFlags) {
+        if let modifier = SidedModifierKey(keyCode: changedKeyCode) {
+            if activeSidedModifiers.contains(modifier) {
+                activeSidedModifiers.remove(modifier)
+            } else {
+                activeSidedModifiers.insert(modifier)
+            }
+        }
+        if flags.intersection(HotkeyBinding.allModifiers).isEmpty {
+            activeSidedModifiers.removeAll()
+        }
     }
 }

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -9,6 +9,10 @@ final class SettingsModel: ObservableObject {
     @Published var allWindows: HotkeyBinding = HotkeyConfig.shared.allWindows
     @Published var currentApp: HotkeyBinding = HotkeyConfig.shared.currentApp
     @Published var stickyToggle: HotkeyBinding? = HotkeyConfig.shared.stickyToggle
+    @Published var allWindowsForward: HotkeyBinding = HotkeyConfig.shared.allWindowsForward
+    @Published var allWindowsBackward: HotkeyBinding = HotkeyConfig.shared.allWindowsBackward
+    @Published var currentAppForward: HotkeyBinding = HotkeyConfig.shared.currentAppForward
+    @Published var currentAppBackward: HotkeyBinding = HotkeyConfig.shared.currentAppBackward
 
     init() { refresh() }
 
@@ -19,6 +23,10 @@ final class SettingsModel: ObservableObject {
         allWindows = HotkeyConfig.shared.allWindows
         currentApp = HotkeyConfig.shared.currentApp
         stickyToggle = HotkeyConfig.shared.stickyToggle
+        allWindowsForward = HotkeyConfig.shared.allWindowsForward
+        allWindowsBackward = HotkeyConfig.shared.allWindowsBackward
+        currentAppForward = HotkeyConfig.shared.currentAppForward
+        currentAppBackward = HotkeyConfig.shared.currentAppBackward
     }
 
     func setLaunchAtLogin(_ enabled: Bool) {
@@ -50,6 +58,26 @@ final class SettingsModel: ObservableObject {
     func updateStickyToggle(_ b: HotkeyBinding?) {
         HotkeyConfig.shared.stickyToggle = b
         stickyToggle = b
+    }
+
+    func updateAllWindowsForward(_ b: HotkeyBinding) {
+        HotkeyConfig.shared.allWindowsForward = b
+        allWindowsForward = b
+    }
+
+    func updateAllWindowsBackward(_ b: HotkeyBinding) {
+        HotkeyConfig.shared.allWindowsBackward = b
+        allWindowsBackward = b
+    }
+
+    func updateCurrentAppForward(_ b: HotkeyBinding) {
+        HotkeyConfig.shared.currentAppForward = b
+        currentAppForward = b
+    }
+
+    func updateCurrentAppBackward(_ b: HotkeyBinding) {
+        HotkeyConfig.shared.currentAppBackward = b
+        currentAppBackward = b
     }
 
     func resetHotkeys() {
@@ -143,12 +171,26 @@ struct SettingsView: View {
 
                 section("Hotkeys") {
                     VStack(alignment: .leading, spacing: 12) {
-                        hotkeyRow(label: "All windows", binding: model.allWindows) { b in
+                        hotkeyRow(label: "All windows summon", binding: model.allWindows) { b in
                             apply(b) { model.updateAllWindows($0) }
                         }
-                        hotkeyRow(label: "Current app", binding: model.currentApp) { b in
+                        navigationKeyRow(label: "All windows forward", binding: model.allWindowsForward) { b in
+                            applyNavigation(b) { model.updateAllWindowsForward($0) }
+                        }
+                        navigationKeyRow(label: "All windows backward", binding: model.allWindowsBackward) { b in
+                            applyNavigation(b) { model.updateAllWindowsBackward($0) }
+                        }
+                        Divider().opacity(0.4)
+                        hotkeyRow(label: "Current app summon", binding: model.currentApp) { b in
                             apply(b) { model.updateCurrentApp($0) }
                         }
+                        navigationKeyRow(label: "Current app forward", binding: model.currentAppForward) { b in
+                            applyNavigation(b) { model.updateCurrentAppForward($0) }
+                        }
+                        navigationKeyRow(label: "Current app backward", binding: model.currentAppBackward) { b in
+                            applyNavigation(b) { model.updateCurrentAppBackward($0) }
+                        }
+                        Divider().opacity(0.4)
                         stickyToggleRow
                         if let msg = rejectMessage {
                             Text(msg)
@@ -156,7 +198,7 @@ struct SettingsView: View {
                                 .foregroundStyle(.red)
                         }
                         HStack {
-                            Text("Sticky: ⌘W/Q/H · Hold: ⇧⌘W/Q/H · ⇧ reverse")
+                            Text("Sticky: ⌘W/Q/H · Hold: ⇧⌘W/Q/H")
                                 .font(.system(size: 11))
                                 .foregroundStyle(.secondary)
                             Spacer()
@@ -338,14 +380,14 @@ struct SettingsView: View {
         HStack(spacing: 12) {
             Text("Sticky toggle")
                 .font(.system(size: 13, weight: .medium))
-                .frame(width: 100, alignment: .leading)
+                .frame(width: 138, alignment: .leading)
             KeyRecorderField(
-                initialBinding: model.stickyToggle ?? HotkeyBinding(keyCode: 0, modifiersRaw: 0),
+                initialBinding: model.stickyToggle ?? .empty,
                 onCapture: { b in apply(b) { model.updateStickyToggle($0) } },
                 accent: prefs.accent.color,
                 placeholder: "Not set"
             )
-            .frame(width: 180, height: 28)
+            .frame(width: 160, height: 28)
             if model.stickyToggle != nil {
                 Button("Clear") { model.updateStickyToggle(nil) }
                     .controlSize(.small)
@@ -587,9 +629,25 @@ struct SettingsView: View {
         HStack(spacing: 12) {
             Text(label)
                 .font(.system(size: 13, weight: .medium))
-                .frame(width: 100, alignment: .leading)
+                .frame(width: 138, alignment: .leading)
             KeyRecorderField(initialBinding: binding, onCapture: onCapture, accent: prefs.accent.color)
-                .frame(width: 180, height: 28)
+                .frame(width: 160, height: 28)
+            Spacer()
+        }
+    }
+
+    private func navigationKeyRow(label: String, binding: HotkeyBinding, onCapture: @escaping (HotkeyBinding) -> Void) -> some View {
+        HStack(spacing: 12) {
+            Text(label)
+                .font(.system(size: 13, weight: .medium))
+                .frame(width: 138, alignment: .leading)
+            KeyRecorderField(
+                initialBinding: binding,
+                onCapture: onCapture,
+                accent: prefs.accent.color,
+                allowModifierOnly: true
+            )
+            .frame(width: 160, height: 28)
             Spacer()
         }
     }
@@ -627,6 +685,15 @@ struct SettingsView: View {
 
     private func apply(_ b: HotkeyBinding, save: (HotkeyBinding) -> Void) {
         if let msg = HotkeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags) {
+            rejectMessage = msg
+        } else {
+            rejectMessage = nil
+            save(b)
+        }
+    }
+
+    private func applyNavigation(_ b: HotkeyBinding, save: (HotkeyBinding) -> Void) {
+        if let msg = NavigationKeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags) {
             rejectMessage = msg
         } else {
             rejectMessage = nil
@@ -702,6 +769,7 @@ struct KeyRecorderField: NSViewRepresentable {
     let onCapture: (HotkeyBinding) -> Void
     var accent: Color = .accentColor
     var placeholder: String = "—"
+    var allowModifierOnly: Bool = false
 
     func makeNSView(context: Context) -> KeyRecorderNSView {
         let v = KeyRecorderNSView()
@@ -709,6 +777,7 @@ struct KeyRecorderField: NSViewRepresentable {
         v.onCapture = onCapture
         v.accentNSColor = NSColor(accent)
         v.placeholder = placeholder
+        v.allowModifierOnly = allowModifierOnly
         return v
     }
 
@@ -719,6 +788,7 @@ struct KeyRecorderField: NSViewRepresentable {
         view.onCapture = onCapture
         view.accentNSColor = NSColor(accent)
         view.placeholder = placeholder
+        view.allowModifierOnly = allowModifierOnly
     }
 }
 
@@ -726,10 +796,13 @@ final class KeyRecorderNSView: NSView {
     var onCapture: ((HotkeyBinding) -> Void)?
     var accentNSColor: NSColor = .controlAccentColor { didSet { redraw() } }
     var placeholder: String = "—" { didSet { redraw() } }
+    var allowModifierOnly: Bool = false
     private let label = NSTextField(labelWithString: "")
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var recording = false { didSet { redraw() } }
+    private var activeSidedModifiers = Set<SidedModifierKey>()
+    private var pendingModifierOnly = Set<SidedModifierKey>() { didSet { redraw() } }
 
     var binding: HotkeyBinding = .defaultAllWindows {
         didSet { redraw() }
@@ -773,6 +846,8 @@ final class KeyRecorderNSView: NSView {
     // Session tap at head fires first, swallows.
     private func startRecording() {
         recording = true
+        activeSidedModifiers = []
+        pendingModifierOnly = []
         window?.makeFirstResponder(self)
         let mask = CGEventMask((1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.flagsChanged.rawValue))
         let info = Unmanaged.passUnretained(self).toOpaque()
@@ -794,18 +869,42 @@ final class KeyRecorderNSView: NSView {
         if let src = runLoopSource { CFRunLoopRemoveSource(CFRunLoopGetCurrent(), src, .commonModes) }
         eventTap = nil
         runLoopSource = nil
+        activeSidedModifiers = []
+        pendingModifierOnly = []
         recording = false
     }
 
     fileprivate func capture(_ type: CGEventType, _ event: CGEvent) -> Unmanaged<CGEvent>? {
-        if type == .flagsChanged { return nil }
-        guard type == .keyDown else { return Unmanaged.passUnretained(event) }
+        let mods: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
         let kc = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
+        if type == .flagsChanged {
+            updateSidedModifiers(changedKeyCode: kc, flags: event.flags)
+            guard allowModifierOnly else { return nil }
+            if activeSidedModifiers.isEmpty, !pendingModifierOnly.isEmpty {
+                let b = HotkeyBinding.modifierOnly(pendingModifierOnly)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    self.binding = b
+                    self.onCapture?(b)
+                    self.stopRecording(commit: true)
+                }
+            } else if !activeSidedModifiers.isEmpty {
+                pendingModifierOnly.formUnion(activeSidedModifiers)
+            }
+            return nil
+        }
+        guard type == .keyDown else { return Unmanaged.passUnretained(event) }
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             if kc != 53 {
-                let mods: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
-                let b = HotkeyBinding(keyCode: UInt16(kc), modifiersRaw: event.flags.intersection(mods).rawValue)
+                let genericFlags = self.activeSidedModifiers.isEmpty
+                    ? event.flags.intersection(mods)
+                    : SidedModifierKey.flags(for: self.activeSidedModifiers)
+                let b = HotkeyBinding(
+                    keyCode: UInt16(kc),
+                    modifiersRaw: genericFlags.rawValue,
+                    sidedModifiers: self.activeSidedModifiers.isEmpty ? nil : self.activeSidedModifiers
+                )
                 self.binding = b
                 self.onCapture?(b)
             }
@@ -816,12 +915,16 @@ final class KeyRecorderNSView: NSView {
 
     private func redraw() {
         if recording {
-            label.stringValue = "Press a key…"
+            if allowModifierOnly && !pendingModifierOnly.isEmpty {
+                label.stringValue = "Release \(HotkeyBinding.modifierOnly(pendingModifierOnly).displayString)"
+            } else {
+                label.stringValue = "Press a key…"
+            }
             label.textColor = .secondaryLabelColor
             layer?.borderColor = accentNSColor.cgColor
             layer?.backgroundColor = accentNSColor.withAlphaComponent(0.10).cgColor
         } else {
-            if binding.keyCode == 0 && binding.modifiersRaw == 0 {
+            if binding.isEmpty {
                 label.stringValue = placeholder
                 label.textColor = .tertiaryLabelColor
             } else {
@@ -830,6 +933,19 @@ final class KeyRecorderNSView: NSView {
             }
             layer?.borderColor = NSColor.separatorColor.cgColor
             layer?.backgroundColor = NSColor.controlBackgroundColor.withAlphaComponent(0.6).cgColor
+        }
+    }
+
+    private func updateSidedModifiers(changedKeyCode: CGKeyCode, flags: CGEventFlags) {
+        if let modifier = SidedModifierKey(keyCode: changedKeyCode) {
+            if activeSidedModifiers.contains(modifier) {
+                activeSidedModifiers.remove(modifier)
+            } else {
+                activeSidedModifiers.insert(modifier)
+            }
+        }
+        if flags.intersection(HotkeyBinding.allModifiers).isEmpty {
+            activeSidedModifiers.removeAll()
         }
     }
 }

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -179,11 +179,27 @@ struct SwitchView: View {
         .transition(.scale(scale: 0.98).combined(with: .opacity))
     }
 
+    private var forwardHintKey: String {
+        switch model.mode {
+        case .allWindows: return HotkeyConfig.shared.allWindowsForward.displayString
+        case .currentApp: return HotkeyConfig.shared.currentAppForward.displayString
+        }
+    }
+
+    private var backwardHintKey: String {
+        switch model.mode {
+        case .allWindows: return HotkeyConfig.shared.allWindowsBackward.displayString
+        case .currentApp: return HotkeyConfig.shared.currentAppBackward.displayString
+        }
+    }
+
     private var hintStrip: some View {
         Group {
             if prefs.verticalList {
                 HStack(spacing: 8) {
                     hint("↵", "switch")
+                    hint(forwardHintKey, "forward")
+                    hint(backwardHintKey, "back")
                     compactHint("↑↓", "nav")
                     compactHint("1-9", "pick")
                     actionHint
@@ -194,6 +210,8 @@ struct SwitchView: View {
             } else {
                 HStack(spacing: 14) {
                     hint("↵", "switch")
+                    hint(forwardHintKey, "forward")
+                    hint(backwardHintKey, "back")
                     hint("←↑↓→", "navigate")
                     hint("1-9", "pick")
                     actionHint


### PR DESCRIPTION
Hi,

I am coming from alt+tab, where the default behavior is that tab goes forward, and shift (alone) goes backwards. I wanted to implement the ability to mirror this functionality here. In the process, I noticed that you have
```
Hyperkey support
First-class capture for ⌃⌥⌘⇧ combos in the hotkey rebinder. 
```

On the development roadmap, so I decided to implement that too.

The result is that the user is now able to set multi-hotkey key combinations to summon swift, and can select the foward and backward keys individually. The forward and backward keys are also displayed in the hint strip. Here's how that looks.

<img width="612" height="604" alt="Screenshot 2026-06-17 at 11 25 52" src="https://github.com/user-attachments/assets/45602f57-e8f8-4436-a0e8-2be9eefd3fb6" />

<img width="854" height="544" alt="Screenshot 2026-06-17 at 11 22 19" src="https://github.com/user-attachments/assets/91d4904c-ef08-4824-85aa-59ed03621509" />

Here's a more detailed breakdown:
## What The App Did Before

The old implementation had two user-configurable summon hotkeys:

- All windows: `Cmd+Tab`
- Current app: `Option+Backtick`

Those lived in `HotkeyConfig` as `HotkeyBinding.defaultAllWindows` and
`HotkeyBinding.defaultCurrentApp`. A binding stored:

- `keyCode`: the physical macOS virtual key code.
- `modifiersRaw`: the coarse `CGEventFlags` modifier mask.

`HotkeyManager` installed a global event tap and handled both `keyDown` and
`flagsChanged` events.

On `keyDown`, it checked whether the event matched the all-windows or current-app
summon binding. The matching logic intentionally ignored Shift for summon
hotkeys, because Shift was reserved as the reverse direction modifier.

The old advance behavior was hardcoded:

1. User presses `Cmd+Tab`.
2. If the switcher is not armed, `HotkeyManager` arms all-windows mode.
3. If the switcher is already armed and another matching `Cmd+Tab` keyDown
   arrives, `HotkeyManager` calls `onAdvance?(shift)`.
4. The `shift` boolean came directly from `event.flags.contains(.maskShift)`.
5. `SwitchModel.advance(reverse:)` used that boolean to choose the next or
   previous selected window.

So the behavior was:

- `Cmd+Tab`: advance forward.
- `Cmd+Shift+Tab`: advance backward.

There were no separate user-facing bindings for forward and backward navigation.
There was also no way to bind a pure modifier-only action, because the key
recorder only committed `keyDown` events. A bare modifier key produces
`flagsChanged` events instead.

## What Was Missing

The roadmap item was "Hyperkey support: First-class capture for
Control+Option+Command+Shift combos in the hotkey rebinder."

The previous code did not fully satisfy that because:

- It stored only coarse `CGEventFlags`.
- Coarse flags do not distinguish left and right modifier keys.
- The recorder could capture `Cmd+Shift+Tab`, but not a modifier-only binding
  like bare `Shift`.
- There was no separate forward/back action model.

In other words, `Left Cmd` and `Right Cmd` collapsed into the same
`.maskCommand` value, and Hyperkey was just "all four generic modifier flags"
rather than a first-class physical-key binding.

## What The App Does Now

The updated implementation adds three related pieces:

1. Forward/backward bindings.
2. Modifier-only capture for navigation bindings.
3. Optional side-specific modifier identity.

### Forward And Backward Bindings

`HotkeyConfig` now stores four additional bindings:

- `allWindowsForward`
- `allWindowsBackward`
- `currentAppForward`
- `currentAppBackward`

The defaults preserve the old behavior:

- All windows forward: `Tab`
- All windows backward: `Shift+Tab`
- Current app forward: `Backtick`
- Current app backward: `Shift+Backtick`

These are interpreted relative to the already-held summon modifier. For example,
while all-windows mode is armed by `Cmd+Tab`, a forward binding of plain `Tab`
matches the actual held event `Cmd+Tab`.

This split is what lets a user set all-windows backward to bare `Shift`: once
the switcher is armed by `Cmd+Tab`, pressing Shift can be treated as the backward
navigation action.

### Picker Hint Strip Updates

The picker now shows the active forward and backward navigation bindings in its
bottom hint strip, using the current configured values from `HotkeyConfig.shared`.
That means the onscreen hint reflects the actual bindings the user has set for
all-windows or current-app mode.

### Modifier-Only Navigation

`HotkeyBinding` now has a sentinel `modifierOnlyKeyCode` value. A binding with
that key code and non-zero modifiers means "this action is triggered by
modifier keys alone."

The key recorder can opt into this behavior with `allowModifierOnly`.
Only navigation rows currently use that option. Summon hotkeys and sticky toggle
still require a real key press.

The recorder handles modifier-only capture like this:

1. User clicks a navigation key recorder.
2. User presses one or more modifier keys.
3. The recorder sees `flagsChanged` events and tracks the active modifiers.
4. When all modifiers are released, the recorder commits a modifier-only
   `HotkeyBinding`.

That is why bare `Shift` can now be saved as a backward action.

### Side-Specific Modifiers

`SidedModifierKey` models exact physical modifier keys:

- `leftShift`, `rightShift`
- `leftControl`, `rightControl`
- `leftOption`, `rightOption`
- `leftCommand`, `rightCommand`

Each case maps from a macOS virtual key code. These should be physical modifier
key codes, not EN-US character layout codes.

`HotkeyBinding` now has:

- `modifiersRaw`: the old generic flags, preserved for compatibility.
- `sidedModifiers`: optional exact left/right modifier identity.

If `sidedModifiers` is `nil`, the binding is legacy/generic. Existing saved
preferences decode this way.

If `sidedModifiers` is non-nil, matching is side-specific. For example:

- A binding saved with `leftCommand` should not match `rightCommand`.
- A binding saved with `leftShift` should not match `rightShift`.

The display string also reflects the exact side:

- `L⌘`
- `R⌘`
- `L⇧`
- `R⇧`

For Hyperkey-style bindings, a newly recorded binding can display something
like:

`L⌃L⌥L⇧L⌘Tab`

## How Matching Works Now

`HotkeyManager` tracks side-specific modifier state from `flagsChanged` events.
This is necessary because `CGEventFlags` only says "Command is down"; it does
not say which Command key is down.

The manager stores:

- `previousFlags`
- `activeSidedModifiers`

On every `flagsChanged` event, it:

1. Reads the event key code.
2. Converts it to a `SidedModifierKey` when possible.
3. Toggles that modifier in `activeSidedModifiers`.
4. Clears the set if no generic modifier flags are still held.

On `keyDown`, matching gets both:

- the generic `CGEventFlags`
- the exact `activeSidedModifiers`

Bindings decide whether to use generic or side-specific matching:

- Old/default bindings use `modifiersRaw`.
- Newly recorded side-aware bindings use `sidedModifiers`.

## Why Defaults Are Still Generic

Defaults remain generic on purpose. The default `Cmd+Tab` should work with
either left or right Command, because that is what users expect from a default
shortcut.

Side-specific behavior starts when a user records a binding. That lets a user
intentionally bind `L⌘Tab` without breaking existing default behavior.

This is also good for backward compatibility: old saved preferences have no
`sidedModifiers` field, so they continue to decode and behave as generic
bindings.

## Why The Backward Key Can Be Bare Shift

The new backward binding is evaluated while the picker is already armed.
For all-windows mode, the arming modifier is normally Command. The navigation
matching code subtracts the arming primary modifier from the currently held
modifiers before comparing against the configured navigation binding.

So if the user holds `Cmd` and presses `Shift`:

- Raw active modifiers: `Cmd + Shift`
- Arm primary modifier: `Cmd`
- Navigation modifiers after normalization: `Shift`
- Backward binding: `Shift`
- Result: backward navigation

This normalization is why a binding shown as `Tab` can still match the actual
physical event `Cmd+Tab` while the picker is armed.

## Design Tradeoffs

### Good Parts

- Existing defaults and saved preferences remain compatible.
- Forward/backward navigation is no longer hardcoded to Shift.
- Modifier-only navigation is supported without changing summon semantics.
- Newly recorded bindings can distinguish left/right modifier keys.
- Most of the key-binding semantics are centralized in `HotkeyBinding` and
  `SidedModifierKey`.

### Things Worth Reviewing Carefully

- `HotkeyConfig.swift` now contains persistence, binding semantics, validators,
  sided modifiers, and key display. This matches the existing local style, but
  the file is getting broad.
- `HotkeyManager` has more matching helpers now. They are private and scoped,
  but the normalization rules are subtle.
- The exact left/right modifier state depends on seeing `flagsChanged` events.
  That is normal for event taps, but it is stateful code and should be reviewed
  with that in mind.
- Newly recorded modifier bindings are side-specific (distinguish R⌘ and L⌘). There is not currently a
  UI affordance for "record this modifier generically."

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces hyperkey / side-specific modifier support and separates navigation into explicit, user-configurable forward and backward bindings for each summon mode. The `SidedModifierKey` enum maps physical modifier key codes to left/right variants; `HotkeyBinding` gains an optional `sidedModifiers` set and a `modifierOnlyKeyCode` sentinel; `HotkeyManager` tracks per-side modifier state via a toggle-based `activeSidedModifiers` set; and `SettingsView` adds four new `KeyRecorderField` rows that can capture modifier-only chords.

- **Summon key decoupled from navigation**: pressing the summon key while the picker is open no longer unconditionally calls `onAdvance`; forward/backward are handled exclusively by the new configurable bindings (defaulting to `Tab` / `\u21e7Tab`, preserving existing behaviour).
- **Modifier-only capture**: navigation rows opt-in to `allowModifierOnly`, committing when all modifiers are released; summon and sticky-toggle rows still require a real key press.
- **Hint strip updated**: `SwitchView` reads the active forward/backward binding strings from `HotkeyConfig.shared` and displays them in the bottom hint strip, replacing the hard-coded `\u21e7 reverse` hint.

<h3>Confidence Score: 3/5</h3>

The core navigation logic is well-structured but the stateful sided-modifier tracking carries a correctness gap that can produce a transient wrong-direction navigation action.

The reload() path leaves activeSidedModifiers and previousFlags populated across a tap reinstall, meaning the toggle-based tracker can be inverted for any modifier held at that moment. Under stale state the next modifier-only navigation event fires in the wrong direction until the user fully releases all keys. The rest of the PR checks out.

**Files Needing Attention:** HotkeyManager.swift — reload() and reinstallIfNeeded() need the two new state fields cleared; HotkeyConfig.swift — the matchesTrigger Shift-branch change deserves a release note.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Sources/Switch/HotkeyConfig.swift | Adds SidedModifierKey, expands HotkeyBinding with sidedModifiers and modifier-only sentinel, adds four forward/backward bindings to HotkeyConfig, and introduces NavigationKeyValidator; the new matchesTrigger Shift-branch is a silent behavioural change for any saved Shift-containing summon binding. |
| Sources/Switch/HotkeyManager.swift | Adds stateful side-specific modifier tracking (activeSidedModifiers, previousFlags), reroutes navigation through explicit forward/backward bindings, and introduces several private matching helpers; stale state is not cleared on tap reinstall/reload, and backward binding is always evaluated before forward with no conflict guard. |
| Sources/Switch/SettingsView.swift | Adds four navigation binding rows with a new navigationKeyRow helper and KeyRecorderField allowModifierOnly flag; applyNavigation validates with NavigationKeyValidator but does not cross-check sibling bindings against each other. |
| Sources/Switch/SwitchView.swift | Adds forwardHintKey/backwardHintKey computed properties reading from HotkeyConfig.shared and injects them into both hint strip layouts; straightforward and correct. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/Switch/HotkeyManager.swift`, line 356-362 ([link](https://github.com/sanyam-g/switch/blob/228a643dfd8060b9afa5b8eb952385bc48967e29/Sources/Switch/HotkeyManager.swift#L356-L362)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `reload()` calls `uninstallTap()` + `installTap()` but leaves `activeSidedModifiers` and `previousFlags` carrying over from before the reinstall. If a modifier key is held when this runs, the toggle-based tracking in `updateSidedModifiers` will be inverted for that key until the user releases all modifiers and the `flags.isEmpty` safety net fires. During that window, any modifier-only navigation binding will misfire or fail to fire.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Add forward/backwards keys to hint strip"](https://github.com/sanyam-g/switch/commit/228a643dfd8060b9afa5b8eb952385bc48967e29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47782718)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->