### PR TITLE
Add configurable label layout for switcher rows

### DIFF
--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -560,6 +560,19 @@ struct SettingsView: View {
                     .background(rowBackground)
                 }
 
+                section("Labels") {
+                    row(title: "Label layout",
+                        detail: "How the app name and window title are arranged in each row.") {
+                        Picker("", selection: $prefs.labelLayout) {
+                            ForEach(SwitchPreferences.LabelLayout.allCases) { choice in
+                                Text(choice.label).tag(choice)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                    }
+                }
+
             }
             .padding(24)
         }

--- a/Sources/Switch/SwitchPreferences.swift
+++ b/Sources/Switch/SwitchPreferences.swift
@@ -36,8 +36,25 @@ final class SwitchPreferences: ObservableObject {
         }
     }
 
+    enum LabelLayout: String, CaseIterable, Identifiable {
+        case automatic, appAbove, titleAbove, sameLine
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .automatic: return "Automatic"
+            case .appAbove: return "App name first"
+            case .titleAbove: return "Title first"
+            case .sameLine: return "Same line"
+            }
+        }
+    }
+
     @Published var accent: AccentChoice {
         didSet { UserDefaults.standard.set(accent.rawValue, forKey: accentKey) }
+    }
+
+    @Published var labelLayout: LabelLayout {
+        didSet { UserDefaults.standard.set(labelLayout.rawValue, forKey: labelLayoutKey) }
     }
 
     @Published var showCrossSpace: Bool {
@@ -125,6 +142,7 @@ final class SwitchPreferences: ObservableObject {
     }
 
     private let accentKey = "switch.accent"
+    private let labelLayoutKey = "switch.labelLayout"
     private let crossSpaceKey = "switch.showCrossSpace"
     nonisolated static let stickyModeKey = "switch.stickyMode"
     private let disableMouseKey = "switch.disableMouse"
@@ -149,6 +167,7 @@ final class SwitchPreferences: ObservableObject {
 
     private init() {
         accent = AccentChoice(rawValue: UserDefaults.standard.string(forKey: accentKey) ?? "") ?? .system
+        labelLayout = LabelLayout(rawValue: UserDefaults.standard.string(forKey: labelLayoutKey) ?? "") ?? .automatic
         showCrossSpace = (UserDefaults.standard.object(forKey: crossSpaceKey) as? Bool) ?? true
         stickyMode = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
         disableMouse = UserDefaults.standard.bool(forKey: "switch.disableMouse")

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -56,6 +56,64 @@ struct SwitchView: View {
         }
     }
 
+    private func resolvedLabelLayout(grid: Bool) -> SwitchPreferences.LabelLayout {
+        let layout = prefs.labelLayout
+        guard layout == .automatic else { return layout }
+        return grid ? .sameLine : .appAbove
+    }
+
+    @ViewBuilder
+    private func windowLabel(for window: WindowInfo, grid: Bool) -> some View {
+        // Typography follows the slot, not the content: the top line is the
+        // bold "primary" treatment, the line beneath it is the muted "secondary".
+        let primarySize: CGFloat = grid ? 12 : 13
+        let secondarySize: CGFloat = grid ? 12 : 11
+        let hasTitle = !window.title.isEmpty
+
+        let appPrimary = Text(window.appName)
+            .font(.system(size: primarySize, weight: .medium))
+            .foregroundStyle(.primary).lineLimit(1)
+        let appSecondary = Text(window.appName)
+            .font(.system(size: secondarySize))
+            .foregroundStyle(.secondary).lineLimit(1)
+        let titlePrimary = Text(window.title)
+            .font(.system(size: primarySize, weight: .medium))
+            .foregroundStyle(.primary).lineLimit(1)
+        let titleSecondary = Text(window.title)
+            .font(.system(size: secondarySize))
+            .foregroundStyle(.secondary).lineLimit(1)
+
+        switch resolvedLabelLayout(grid: grid) {
+        case .appAbove, .automatic:
+            VStack(alignment: .leading, spacing: 2) {
+                appPrimary
+                if hasTitle { titleSecondary }
+            }
+        case .titleAbove:
+            // Title takes over the app name's bold primary slot; the app name
+            // demotes beneath it. Fall back to the app name when there's no title.
+            VStack(alignment: .leading, spacing: 2) {
+                if hasTitle {
+                    titlePrimary
+                    appSecondary
+                } else {
+                    appPrimary
+                }
+            }
+        case .sameLine:
+            HStack(spacing: 6) {
+                appPrimary
+                if hasTitle {
+                    Text("·")
+                        .font(.system(size: primarySize))
+                        .foregroundStyle(.tertiary)
+                    titleSecondary
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
     private func windowBadgeText(for window: WindowInfo) -> String {
         if window.isMinimized { return "MINIMIZED" }
         if window.isHidden { return "HIDDEN" }
@@ -367,23 +425,8 @@ struct SwitchView: View {
                 }
             }
 
-            HStack(spacing: 6) {
-                Text(window.appName)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                if !window.title.isEmpty {
-                    Text("·")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.tertiary)
-                    Text(window.title)
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 0)
-            }
-            .padding(.horizontal, 2)
+            windowLabel(for: window, grid: true)
+                .padding(.horizontal, 2)
         }
         .padding(9)
         .modifier(SelectionChrome(selected: selected, hovered: hovered, cornerRadius: 9, accent: prefs.accent.color, namespace: selectionNS, selectedValue: model.selected))
@@ -409,18 +452,7 @@ struct SwitchView: View {
                     Color.clear.frame(width: 32, height: 32)
                 }
             }
-            VStack(alignment: .leading, spacing: 2) {
-                Text(window.appName)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                if !window.title.isEmpty {
-                    Text(window.title)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
+            windowLabel(for: window, grid: false)
             Spacer(minLength: 6)
             if !isSpaceMode && prefs.showStoplights && prefs.verticalShowStoplights && !window.isWindowless {
                 stoplights(for: window)


### PR DESCRIPTION
Implements #66 — a user-configurable layout for how the app name and window title are placed in the switcher rows.

## What

Adds an **Appearance → Labels** preference with four options:

- **Automatic** (default) — preserves today's behavior exactly: same-line in the grid, app-name-above-title in the vertical list. Existing users see no change until they pick something else.
- **App name first** — app name on the bold primary line, title beneath.
- **Title first** — window title takes the bold primary line, app name beneath.
- **Same line** — `App · title` with a `·` separator.

The chosen layout applies to both the grid card and the vertical list row.

## How

- `SwitchPreferences`: new `LabelLayout` enum + `@Published var labelLayout` persisted under `switch.labelLayout`, defaulting to `.automatic` (matches the existing `accent` pattern).
- `SwitchView`: a shared `@ViewBuilder windowLabel(for:grid:)` plus `resolvedLabelLayout(grid:)` that maps `.automatic` → `.sameLine` for the grid and `.appAbove` for the list. Typography follows the slot (bold primary / muted secondary) rather than the content, so "Title first" gives the title the app name's old weight. Per-mode sizes are preserved (grid 12/12; list 13 medium / 11). Inline label code in `tile(...)` and `listRow(...)` now calls the shared builder.
- `SettingsView`: a new "Labels" section in the Appearance tab with a menu-style `Picker` bound to `$prefs.labelLayout`.

## Testing

Built Debug locally and smoke-tested in both grid and vertical-list modes: all four options render correctly, Automatic matches the original look, and rows with an empty window title show no stray separator or blank line.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a user-configurable **Label Layout** preference (Automatic / App name first / Title first / Same line) that controls how the app name and window title are arranged in both the grid tile and vertical list row. The implementation is clean and follows established patterns in the codebase.

- **`SwitchPreferences`** gains a `LabelLayout` enum and a `@Published var labelLayout` stored under `switch.labelLayout`, modelled identically to `AccentChoice`/`accent`.
- **`SwitchView`** replaces the two inline label blocks with a shared `@ViewBuilder windowLabel(for:grid:)` routed through `resolvedLabelLayout(grid:)`, which maps `.automatic` to the old per-mode defaults so existing users see no change.
- **`SettingsView`** adds a "Labels" section with a menu-style `Picker` that matches the rest of the Appearance tab.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the feature is additive, defaults to `.automatic` so existing users are unaffected, and persistence follows the established `UserDefaults` pattern.

The change is purely additive with two minor issues: a dead `.automatic` arm in the `windowLabel` switch, and a font-size mismatch (13 pt vs 11 pt) in the `sameLine` branch when used in vertical-list mode.

**Files Needing Attention:** Sources/Switch/SwitchView.swift — specifically the `windowLabel` switch and the font-size handling in the `sameLine` branch for non-grid contexts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Sources/Switch/SwitchPreferences.swift | Adds `LabelLayout` enum with four cases and a `@Published var labelLayout` property persisted under `switch.labelLayout`; follows the exact same pattern as `AccentChoice`/`accent`. |
| Sources/Switch/SettingsView.swift | Adds a "Labels" section inside the Appearance tab with a menu-style `Picker` bound to `$prefs.labelLayout`; correctly mirrors the pattern used by other pickers in the same tab. |
| Sources/Switch/SwitchView.swift | Introduces `resolvedLabelLayout(grid:)` and a shared `@ViewBuilder windowLabel(for:grid:)`; the `.automatic` arm in the switch is dead code, and the sameLine case uses a smaller secondary font size (11pt) alongside a larger primary (13pt) when displayed in vertical-list mode. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[windowLabel called] --> B{resolvedLabelLayout}
    B --> C{prefs.labelLayout == .automatic?}
    C -- Yes --> D{grid?}
    D -- Yes --> E[return .sameLine]
    D -- No --> F[return .appAbove]
    C -- No --> G[return layout as-is]
    E --> H[Switch on resolved layout]
    F --> H
    G --> H
    H --> I[.appAbove
VStack: appPrimary / titleSecondary]
    H --> J[.titleAbove
VStack: titlePrimary / appSecondary
or appPrimary if no title]
    H --> K[.sameLine
HStack: appPrimary · titleSecondary]
    I --> L[Rendered in tile or listRow]
    J --> L
    K --> L
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add configurable label layout for switch..."](https://github.com/sanyam-g/switch/commit/a33ccaf210a4ddc8507200a6bae861c244f5e8d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47782716)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->