### PR TITLE
Prune orderOut'd windows that still report a Space (phantom entries on macOS 26)

### DIFF
--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -150,6 +150,7 @@ enum WindowEnumerator {
         metadata: (labels: [Int: (label: String, isFullscreen: Bool)], order: [Int]),
         stageManager: Bool
     ) -> [WindowInfo] {
+        let activeSpace = Int(CGSGetActiveSpace(cid))
         return candidates.compactMap { w in
             var out = w
             if out.isHidden {
@@ -163,6 +164,15 @@ enum WindowEnumerator {
             }
             let arr = [NSNumber(value: w.id)] as CFArray
             let spaces = CGSCopySpacesForWindows(cid, 7, arr)?.takeRetainedValue() as? [Int] ?? []
+            // macOS 26 keeps the Space assignment for orderOut'd windows, so a
+            // closed window can still report the *active* Space here. A real
+            // active-Space window would be in the on-screen list (isCrossSpace
+            // false), and a real cross-Space window lives on another Space —
+            // so an off-screen window claiming the active Space with no live
+            // AX window is a closed leftover. Drop it.
+            if out.isCrossSpace, spaces.contains(activeSpace), !ax.axBacked.contains(w.id) {
+                return nil
+            }
             if spaces.isEmpty {
                 // Empty Space list + no AX window = orderOut'd ghost, drop it.
                 // Empty Space list + live AX window = a real window the window


### PR DESCRIPTION
## Symptom
On macOS 26, closing a window in apps that hide-on-close (Messages conversations, Notes, Electron apps like Google Gemini) leaves a **phantom entry** in the switcher: a blank tile badged with the *current* desktop's name (e.g. "DESKTOP 1"), for a window that no longer exists. The thumbnail is blank because there is nothing left to capture.

## Root cause
Those apps `orderOut` windows on close instead of destroying them, so the windows stay in `CGWindowList(.optionAll)`. The existing ghost pruning in `annotateAndPrune` assumes an orderOut'd window has an **empty Space list**:

```swift
if spaces.isEmpty {
    // Empty Space list + no AX window = orderOut'd ghost, drop it.
```

On macOS 26 the window server **keeps the Space assignment for orderOut'd windows**, so they sail past this check, get annotated with a Space label, and land in the cross-Space section.

## Fix
Add the complementary check: an off-screen window (`isCrossSpace`) claiming the **active** Space with no live AX window cannot be real — a real active-Space window would be in the on-screen list, and a real cross-Space window lives on another Space. Drop it.

Minimized and hidden windows return before the guard, so their handling is unchanged. Real cross-Space windows are unaffected (`spaces.contains(activeSpace)` is false for them). Stage Manager's off-stage windows keep their empty-Space-list path.

## Verification (macOS 26.5)
Using the Debug build's `switch.debug.dump` harness:
- **Before:** 3 cross-Space entries, all orderOut'd ghosts claiming the active Space (Messages, Notes, Google Gemini — all closed, blank tiles in the picker)
- **After:** 0 ghost entries; all live windows enumerate correctly, minimized badging still works

## Repro for review
On macOS 26: open a Messages conversation window, close it with ⌘W (app keeps running), invoke Switch — a blank "Messages" tile appears badged with your current desktop's name. With this patch it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)