### PR TITLE
Fixed sticky-mode quick tap not selecting the previous window

### DIFF
--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -60,6 +60,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             model?.commit()
             window?.dismiss()
         }
+        hotkey.onQuickSwitch = { [weak self, weak model, weak window] in
+            self?.cancelPendingPresent()
+            model?.commitRecent()
+            window?.dismiss()
+        }
         model.commitAndDismiss = { [weak self, weak model, weak window] in
             self?.cancelPendingPresent()
             self?.hotkey?.clearArmed()

--- a/Sources/Switch/HotkeyManager.swift
+++ b/Sources/Switch/HotkeyManager.swift
@@ -9,6 +9,7 @@ final class HotkeyManager {
     var onArm: ((Mode) -> Void)?
     var onAdvance: ((Bool) -> Void)?
     var onCommit: (() -> Void)?
+    var onQuickSwitch: (() -> Void)?
     var onCancel: (() -> Void)?
     var onCloseSelected: (() -> Void)?
     var onCloseSelectedApp: (() -> Void)?
@@ -355,12 +356,24 @@ final class HotkeyManager {
 
             if !armingHeld {
                 let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
-                let quickTap = (armedAt.map { Date().timeIntervalSince($0) * 1000 < Self.stickyQuickTapMS } ?? false) && !advanced
-                if !sticky || quickTap {
+                if !sticky {
                     clearArmedLocked()
                     stateLock.unlock()
                     DispatchQueue.main.async { [weak self] in
                         self?.onCommit?()
+                    }
+                    return Unmanaged.passUnretained(event)
+                }
+                // A tap released before the picker would have appeared is a classic
+                // alt-tab switch, not a request to float the panel.
+                let delayMS = (UserDefaults.standard.object(forKey: SwitchPreferences.pickerActivationDelayKey) as? Double) ?? SwitchPreferences.defaultPickerActivationDelay
+                let thresholdMS = max(Self.stickyQuickTapMS, delayMS)
+                let quickTap = (armedAt.map { Date().timeIntervalSince($0) * 1000 < thresholdMS } ?? false) && !advanced
+                if quickTap {
+                    clearArmedLocked()
+                    stateLock.unlock()
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onQuickSwitch?()
                     }
                     return Unmanaged.passUnretained(event)
                 }

--- a/Sources/Switch/SwitchModel.swift
+++ b/Sources/Switch/SwitchModel.swift
@@ -108,12 +108,7 @@ final class SwitchModel: ObservableObject {
                     selected = 0
                 }
             } else {
-                // Own windows aren't listed, so with Switch frontmost index 0 is already the previous window.
-                // Only treat Switch as frontmost when it genuinely owns a visible key window (Settings/About/
-                // onboarding); the picker panel can't become key, so keyWindow != nil rules out the stale
-                // "still frontmost after closing a window" state behind #90.
-                let selfFront = armFrontmostPID == ProcessInfo.processInfo.processIdentifier && armSelfHadKeyWindow
-                selected = (SwitchPreferences.shared.stickyMode || selfFront) ? 0 : (filteredWindows.count > 1 ? 1 : 0)
+                selected = SwitchPreferences.shared.stickyMode ? 0 : recentIndex(in: filteredWindows)
             }
         } else if changed {
             let list = filteredWindows
@@ -369,6 +364,28 @@ final class SwitchModel: ObservableObject {
         guard !filterText.isEmpty else { return }
         filterText.removeLast()
         selected = 0
+    }
+
+    // Index of the previous window: 1, or 0 when Switch itself was frontmost since our
+    // own windows aren't listed. Only treat Switch as frontmost when it genuinely owns a
+    // visible key window (Settings/About/onboarding); the picker panel can't become key,
+    // so keyWindow != nil rules out the stale "still frontmost after closing a window"
+    // state behind #90.
+    private func recentIndex(in list: [WindowInfo]) -> Int {
+        let selfFront = armFrontmostPID == ProcessInfo.processInfo.processIdentifier && armSelfHadKeyWindow
+        return (selfFront || list.count <= 1) ? 0 : 1
+    }
+
+    // Sticky-mode quick tap: the panel never floated, so behave like a non-sticky
+    // commit — switch to the recent window instead of the preselected current one.
+    // Spaces mode already preselects the next space regardless of sticky.
+    func commitRecent() {
+        if mode != .spaces {
+            let list = filteredWindows
+            let idx = recentIndex(in: list)
+            if list.indices.contains(idx) { selected = idx }
+        }
+        commit()
     }
 
     func commit() {


### PR DESCRIPTION
With sticky mode on, a quick cmd-tab did nothing: the picker opens with the current window selected (so you can browse), so a fast tap just re-focused the window you were already on. 

Quick taps now switch to the previous window, like sticky mode off. 
A tap also counts as quick if it's released before the picker window would have appeared, not just under the fixed 200ms.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where a quick cmd-tab in sticky mode re-focused the already-active window instead of switching to the previous one. The picker starts with the current window pre-selected in sticky mode, so a fast tap was a no-op; the fix routes quick taps through a new `onQuickSwitch` callback that calls `commitRecent()`, explicitly selecting the previous window before committing.

- **`HotkeyManager`**: Splits the key-up handler so non-sticky taps still use `onCommit`, while sticky quick-taps (released before `max(stickyQuickTapMS, pickerActivationDelay)`) fire the new `onQuickSwitch` callback.
- **`SwitchModel`**: Extracts `recentIndex(in:)` (index 1, or 0 when Switch itself was frontmost) and adds `commitRecent()` which moves the selection to the previous window before calling `commit()`. The initial selection for sticky mode is simplified to always be 0, since quick taps now take the correct path.
- **`AppDelegate`**: Wires `onQuickSwitch` with `cancelPendingPresent()` + `commitRecent()` + `dismiss()`, consistent with the existing callback pattern.

<h3>Confidence Score: 5/5</h3>

- The change is safe to merge — it adds a well-isolated code path for sticky-mode quick taps without touching any shared state paths used by normal commits or cancels.
- The logic is straightforward: `commitRecent()` sets the selection to index 1 then delegates to the existing `commit()`, and both callers and callees are `@MainActor`-isolated so there are no races with the async window-list refresh. The `onQuickSwitch` wiring in `AppDelegate` mirrors the existing `onCommit` pattern exactly. The threshold concern (already discussed in a prior review thread) is a pre-existing trade-off, not a new defect introduced here.
- No files require special attention. The threshold logic in `HotkeyManager.swift` around `max(stickyQuickTapMS, delayMS)` was flagged in a prior thread and is the only nuanced area.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Sources/Switch/HotkeyManager.swift | Adds `onQuickSwitch` callback and splits the sticky-mode key-up path: non-sticky still calls `onCommit`; sticky quick-taps now call `onQuickSwitch` instead. The threshold uses `max(stickyQuickTapMS, delayMS)` which can make the picker briefly flash at default settings (already flagged in a previous thread). |
| Sources/Switch/SwitchModel.swift | Extracts `recentIndex(in:)` from the arm path and adds `commitRecent()` which sets selection to the previous window before calling `commit()`. The initial-arm selection for sticky mode is simplified to always start at 0. Logic is correct and the `@MainActor` isolation prevents any race with the async window-list refresh. |
| Sources/Switch/AppDelegate.swift | Wires the new `onQuickSwitch` callback: cancels the pending picker-present timer, calls `commitRecent()`, and dismisses the window — consistent with the existing `onCommit` pattern and correct weak-capture usage. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant HotkeyManager
    participant AppDelegate
    participant SwitchModel
    participant Window

    User->>HotkeyManager: cmd-tab press (arm)
    HotkeyManager->>AppDelegate: onArm(mode)
    AppDelegate->>SwitchModel: "arm(mode) — selected = 0 (sticky)"
    AppDelegate->>AppDelegate: "schedulePresent(delay=130ms)"

    alt Quick tap (released before thresholdMS)
        User->>HotkeyManager: "cmd-tab release (< thresholdMS, !advanced)"
        HotkeyManager->>HotkeyManager: clearArmedLocked()
        HotkeyManager->>AppDelegate: onQuickSwitch()
        AppDelegate->>AppDelegate: cancelPendingPresent()
        AppDelegate->>SwitchModel: commitRecent()
        SwitchModel->>SwitchModel: "selected = recentIndex() → 1"
        SwitchModel->>SwitchModel: commit() → focus list[1]
        AppDelegate->>Window: dismiss()
    else Normal sticky hold
        User->>HotkeyManager: "cmd-tab release (>= thresholdMS or advanced)"
        Note over HotkeyManager: falls through — picker stays open
    else Non-sticky mode
        User->>HotkeyManager: cmd-tab release
        HotkeyManager->>AppDelegate: onCommit()
        AppDelegate->>SwitchModel: commit() → focus selected
        AppDelegate->>Window: dismiss()
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix sticky-mode quick tap committing the..."](https://github.com/sanyam-g/switch/commit/c64c976c3316ef3bb425e8b8fbf2c74c95f40576) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47782712)</sub>

<!-- /greptile_comment -->