### PR TITLE
Sort windowless apps by MRU instead of always appending them last

### DIFF
--- a/Sources/Switch/FocusTracker.swift
+++ b/Sources/Switch/FocusTracker.swift
@@ -63,16 +63,22 @@ final class FocusTracker {
 
     /// Touch MRU on app activation as a backstop — AX observers don't always
     /// fire reliably immediately after an app launches, but didActivate does.
+    /// Apps with no focused window (e.g. all windows closed) still get touched
+    /// via their synthetic windowless id, so the "no window" picker entry
+    /// participates in MRU ordering like any other app.
     private func touchFocused(of pid: pid_t) {
         let appAX = AXUIElementCreateApplication(pid)
         var ref: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(appAX, kAXFocusedWindowAttribute as CFString, &ref) == .success,
-              let element = ref else { return }
-        let ax = element as! AXUIElement
-        var id: CGWindowID = 0
-        if _AXUIElementGetWindow(ax, &id) == .success, id != 0 {
-            WindowMRU.touch(id)
+        if AXUIElementCopyAttributeValue(appAX, kAXFocusedWindowAttribute as CFString, &ref) == .success,
+           let element = ref {
+            let ax = element as! AXUIElement
+            var id: CGWindowID = 0
+            if _AXUIElementGetWindow(ax, &id) == .success, id != 0 {
+                WindowMRU.touch(id)
+                return
+            }
         }
+        WindowMRU.touch(WindowInfo.windowlessID(for: pid))
     }
 }
 

--- a/Sources/Switch/SwitchModel.swift
+++ b/Sources/Switch/SwitchModel.swift
@@ -197,7 +197,7 @@ final class SwitchModel: ObservableObject {
                 .sorted { ($0.localizedName ?? "") < ($1.localizedName ?? "") }
                 .map { app in
                     WindowInfo(
-                        id: CGWindowID(0xF0000000) | CGWindowID(UInt32(bitPattern: Int32(app.processIdentifier))),
+                        id: WindowInfo.windowlessID(for: app.processIdentifier),
                         pid: app.processIdentifier,
                         appName: app.localizedName ?? "",
                         title: "",
@@ -206,7 +206,17 @@ final class SwitchModel: ObservableObject {
                         bundleID: app.bundleIdentifier
                     )
                 }
-            final += extras
+            // In MRU modes, merge windowless entries into the same recency ordering
+            // as real windows instead of always appending them at the end — a
+            // windowless app that was just focused should sort like any other app.
+            // staticOrder is rank-based, not recency-based, so it keeps the old
+            // append-at-end behavior for unranked windowless apps.
+            if !SwitchPreferences.shared.staticOrder, let frontmost = ws.first {
+                let rest = WindowMRU.sorted(Array(ws.dropFirst()) + extras, frontmost: nil)
+                final = [frontmost] + rest
+            } else {
+                final = ws + extras
+            }
         }
         let pinned = SwitchPreferences.shared.pinnedBundleIDs
         if !pinned.isEmpty {

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -16,6 +16,12 @@ struct WindowInfo: Identifiable, Hashable {
     var isFullscreenSpace: Bool = false
     var isWindowless: Bool = false
     var bundleID: String?
+
+    /// Stable synthetic CGWindowID for a windowless app's picker entry, so it can be
+    /// tracked in WindowMRU the same way real windows are.
+    static func windowlessID(for pid: pid_t) -> CGWindowID {
+        CGWindowID(0xF0000000) | CGWindowID(UInt32(bitPattern: Int32(pid)))
+    }
 }
 
 enum WindowEnumerator {


### PR DESCRIPTION
Fixes #97

## Problem

With **Include windowless apps** on, windowless picker entries (apps with no open window, e.g. Reminders after closing its window) always sort alphabetically at the very end of the list, no matter how recently they were used. They also can't be pinned from the UI (`SwitchView.swift` hides the pin toggle for `isWindowless` entries), so there was no workaround either.

## Root cause

- `FocusTracker.touchFocused(of:)` only touched `WindowMRU` when the activated app had a focused AX window. Windowless apps have none, so they never got an MRU timestamp.
- `SwitchModel.buildWindowList` always concatenated the windowless `extras` after the MRU-sorted window list, rather than merging them into the same ordering.

## Fix

- Added `WindowInfo.windowlessID(for:)`, a stable synthetic `CGWindowID` (`0xF0000000 | pid`) shared by the windowless picker entry and its MRU tracking — previously this id was only computed inline in `SwitchModel` for display, with nothing to touch it.
- `FocusTracker.touchFocused(of:)` now falls back to touching that synthetic id when the activated app has no focused window, so windowless apps get a real MRU stamp on activation.
- `SwitchModel.buildWindowList` now merges windowless `extras` into the existing MRU-sorted list (`WindowMRU.sorted`) in the two recency-driven modes, keeping the current frontmost-window pin at position 0. `staticOrder` mode is unchanged (still rank-based, appends unranked windowless apps at the end by name) since it isn't recency-based to begin with.

## Testing

Local Xcode toolchain here has an unrelated broken plugin (`IDESimulatorFoundation` dlopen failure) preventing a full `xcodebuild`, so I verified with `swiftc -parse` on the three changed files (no syntax/parse errors) and by tracing the call paths manually against `WindowMRU.sorted`'s existing semantics (stable sort, falls back to original enumeration order for untouched ids). Would appreciate a maintainer build/smoke-test before merge given I couldn't run the full app locally.