### PR TITLE
Fix off-stage Stage Manager windows being misdetected as windowless

### DIFF
--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -200,27 +200,16 @@ enum WindowEnumerator {
 
     // Stage Manager suspends kAXWindowsAttribute for whichever app isn't the current
     // stage, so a real off-stage window reports zero AX windows — indistinguishable
-    // from a closed one via axBacked alone.
+    // from a closed one via axBacked alone. Remembering "was AX-backed at some point"
+    // (no time limit — enumeration only runs at launch and while the picker is open,
+    // so a short TTL would routinely expire between checks) lets it survive being
+    // temporarily un-inspectable. Purged only when the id disappears from CGWindowList
+    // entirely, since off-stage windows keep appearing there, just with junk bounds.
     //
-    // A per-app "Window" menu title match was tried here first and reverted: it can't
-    // tell apart a stray duplicate CGWindowList entry from the real window (both share
-    // the same title), and there's no reliable, app-agnostic way to tell a real window
-    // entry apart from a custom command in that menu — every app tested (Zoom, Mail,
-    // Chrome, Claude) added its own command names a hardcoded exclusion list didn't
-    // know about, each one a fresh false positive. Matching by exact CGWindowID
-    // sidesteps both problems: a duplicate entry with a different id simply never
-    // earns a cache entry on its own.
-    //
-    // Remembering "was AX-backed at some point" (no time limit) lets a real off-stage
-    // window survive being temporarily un-inspectable. A time-based expiry was tried
-    // here and doesn't fit: window enumeration only runs at app launch and while the
-    // picker is actually open (no continuous background polling — see WindowStore /
-    // SwitchModel.startRefreshTimer), so a window confirmed real during an earlier
-    // picker session could easily be un-refreshed for longer than any reasonable TTL,
-    // incorrectly dropping it. Purging only when the id disappears from every
-    // CGWindowList sweep (i.e. actually closed, not just off-stage — off-stage
-    // windows keep appearing in CGWindowList, just with degenerate bounds) is the
-    // correct lifetime for this cache.
+    // A Window-menu title match was tried instead of this and reverted: it isn't
+    // keyed to a specific window id, so it can't tell a stray duplicate CGWindowList
+    // entry apart from the real window, and there's no reliable way to tell a real
+    // per-window menu entry apart from an app's own custom commands in the same menu.
     private static let axEverSeenLock = NSLock()
     private static var axEverSeen: Set<CGWindowID> = []
 
@@ -275,16 +264,8 @@ enum WindowEnumerator {
             let spaces = CGSCopySpacesForWindows(cid, 7, arr)?.takeRetainedValue() as? [Int] ?? []
             if spaces.isEmpty {
                 // Empty Space list + no AX window = orderOut'd ghost, drop it.
-                // Empty Space list + live AX window = a real window the window
-                // server has ordered out (Stage Manager off-stage). With Stage
-                // Manager off that signature is a closed Settings/Preferences
-                // leftover, so it only survives while Stage Manager is on.
-                // Stage Manager suspends AX entirely for whichever app isn't the
-                // current stage, so a real off-stage window can report zero live
-                // AX windows too — indistinguishable from a closed one by
-                // ax.axBacked alone. wasEverAXBacked remembers that this exact
-                // window id was confirmed real earlier, so it survives being
-                // temporarily un-inspectable while off-stage.
+                // Empty Space list + AX-backed (now or previously) = a real window
+                // Stage Manager parked off-stage — only possible while it's on.
                 guard stageManager, ax.axBacked.contains(w.id) || wasEverAXBacked(w.id) else { return nil }
                 out.isCrossSpace = false
                 return out

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -198,18 +198,9 @@ enum WindowEnumerator {
         return (axBacked, minimized)
     }
 
-    // Stage Manager suspends kAXWindowsAttribute for whichever app isn't the current
-    // stage, so a real off-stage window reports zero AX windows — indistinguishable
-    // from a closed one via axBacked alone. Remembering "was AX-backed at some point"
-    // (no time limit — enumeration only runs at launch and while the picker is open,
-    // so a short TTL would routinely expire between checks) lets it survive being
-    // temporarily un-inspectable. Purged only when the id disappears from CGWindowList
-    // entirely, since off-stage windows keep appearing there, just with junk bounds.
-    //
-    // A Window-menu title match was tried instead of this and reverted: it isn't
-    // keyed to a specific window id, so it can't tell a stray duplicate CGWindowList
-    // entry apart from the real window, and there's no reliable way to tell a real
-    // per-window menu entry apart from an app's own custom commands in the same menu.
+    // Stage Manager suspends AX for off-stage apps, so a real off-stage window
+    // looks just like a closed one. Remember windows ever confirmed AX-backed,
+    // no TTL (enumeration is too infrequent for one to make sense).
     private static let axEverSeenLock = NSLock()
     private static var axEverSeen: Set<CGWindowID> = []
 
@@ -263,9 +254,8 @@ enum WindowEnumerator {
             let arr = [NSNumber(value: w.id)] as CFArray
             let spaces = CGSCopySpacesForWindows(cid, 7, arr)?.takeRetainedValue() as? [Int] ?? []
             if spaces.isEmpty {
-                // Empty Space list + no AX window = orderOut'd ghost, drop it.
-                // Empty Space list + AX-backed (now or previously) = a real window
-                // Stage Manager parked off-stage — only possible while it's on.
+                // No Space, never AX-backed = ghost. AX-backed now or before = real
+                // window Stage Manager parked off-stage.
                 guard stageManager, ax.axBacked.contains(w.id) || wasEverAXBacked(w.id) else { return nil }
                 out.isCrossSpace = false
                 return out

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -198,10 +198,29 @@ enum WindowEnumerator {
         return (axBacked, minimized)
     }
 
-    // Stage Manager suspends AX for whichever app isn't the current stage, so a
-    // real off-stage window reports zero AX windows just like a closed one would.
-    // Remembering "was AX-backed at some point this session" lets the off-stage
-    // ghost check in annotateAndPrune tell the two apart instead of pruning both.
+    // Stage Manager suspends kAXWindowsAttribute for whichever app isn't the current
+    // stage, so a real off-stage window reports zero AX windows — indistinguishable
+    // from a closed one via axBacked alone.
+    //
+    // A per-app "Window" menu title match was tried here first and reverted: it can't
+    // tell apart a stray duplicate CGWindowList entry from the real window (both share
+    // the same title), and there's no reliable, app-agnostic way to tell a real window
+    // entry apart from a custom command in that menu — every app tested (Zoom, Mail,
+    // Chrome, Claude) added its own command names a hardcoded exclusion list didn't
+    // know about, each one a fresh false positive. Matching by exact CGWindowID
+    // sidesteps both problems: a duplicate entry with a different id simply never
+    // earns a cache entry on its own.
+    //
+    // Remembering "was AX-backed at some point" (no time limit) lets a real off-stage
+    // window survive being temporarily un-inspectable. A time-based expiry was tried
+    // here and doesn't fit: window enumeration only runs at app launch and while the
+    // picker is actually open (no continuous background polling — see WindowStore /
+    // SwitchModel.startRefreshTimer), so a window confirmed real during an earlier
+    // picker session could easily be un-refreshed for longer than any reasonable TTL,
+    // incorrectly dropping it. Purging only when the id disappears from every
+    // CGWindowList sweep (i.e. actually closed, not just off-stage — off-stage
+    // windows keep appearing in CGWindowList, just with degenerate bounds) is the
+    // correct lifetime for this cache.
     private static let axEverSeenLock = NSLock()
     private static var axEverSeen: Set<CGWindowID> = []
 
@@ -260,14 +279,13 @@ enum WindowEnumerator {
                 // server has ordered out (Stage Manager off-stage). With Stage
                 // Manager off that signature is a closed Settings/Preferences
                 // leftover, so it only survives while Stage Manager is on.
-                //
                 // Stage Manager suspends AX entirely for whichever app isn't the
                 // current stage, so a real off-stage window can report zero live
                 // AX windows too — indistinguishable from a closed one by
-                // ax.axBacked alone. wasEverAXBacked remembers that this id was
-                // confirmed real earlier in the session, so it survives being
+                // ax.axBacked alone. wasEverAXBacked remembers that this exact
+                // window id was confirmed real earlier, so it survives being
                 // temporarily un-inspectable while off-stage.
-                guard (ax.axBacked.contains(w.id) || wasEverAXBacked(w.id)), stageManager else { return nil }
+                guard stageManager, ax.axBacked.contains(w.id) || wasEverAXBacked(w.id) else { return nil }
                 out.isCrossSpace = false
                 return out
             }

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -130,11 +130,13 @@ enum WindowEnumerator {
         }
         let annotatedAll = annotateAndPrune(marked, ax: ax, cid: cid, metadata: metadata, stageManager: stageManager, titlesReliable: titlesReliable)
         let onScreenIDs = Set(onScreen.map(\.id))
+        let allEnumeratedIDs = onScreenIDs.union(everything.map(\.id))
         housekeepGhostState(
             onScreen: onScreenIDs,
-            enumerated: onScreenIDs.union(everything.map(\.id)),
+            enumerated: allEnumeratedIDs,
             axBacked: ax.axBacked
         )
+        purgeAXEverSeen(keeping: allEnumeratedIDs)
         let cross = annotatedAll.filter { !activeIDs.contains($0.id) }
         let reps = spaceRepresentatives(from: annotatedAll, cid: cid, metadata: metadata)
         return FullSnapshot(activeSpace: active, crossSpace: cross, spaceRepresentatives: reps)
@@ -184,6 +186,7 @@ enum WindowEnumerator {
                 if _AXUIElementGetWindow(ax, &id) == .success, id != 0 {
                     axBacked.insert(id)
                     AXWindowCache.store(ax, for: id)
+                    rememberAXBacked(id)
                     var minRef: CFTypeRef?
                     if AXUIElementCopyAttributeValue(ax, kAXMinimizedAttribute as CFString, &minRef) == .success,
                        let isMin = minRef as? Bool, isMin {
@@ -193,6 +196,30 @@ enum WindowEnumerator {
             }
         }
         return (axBacked, minimized)
+    }
+
+    // Stage Manager suspends AX for whichever app isn't the current stage, so a
+    // real off-stage window reports zero AX windows just like a closed one would.
+    // Remembering "was AX-backed at some point this session" lets the off-stage
+    // ghost check in annotateAndPrune tell the two apart instead of pruning both.
+    private static let axEverSeenLock = NSLock()
+    private static var axEverSeen: Set<CGWindowID> = []
+
+    private static func rememberAXBacked(_ id: CGWindowID) {
+        axEverSeenLock.lock(); defer { axEverSeenLock.unlock() }
+        axEverSeen.insert(id)
+    }
+
+    private static func wasEverAXBacked(_ id: CGWindowID) -> Bool {
+        axEverSeenLock.lock(); defer { axEverSeenLock.unlock() }
+        return axEverSeen.contains(id)
+    }
+
+    // A window id that's gone from every CGWindowList sweep is fully closed, not
+    // just off-stage — forget it so the cache doesn't grow unbounded.
+    private static func purgeAXEverSeen(keeping ids: Set<CGWindowID>) {
+        axEverSeenLock.lock(); defer { axEverSeenLock.unlock() }
+        axEverSeen.formIntersection(ids)
     }
 
     // Drop orphaned on-screen entries: no live AX window and no Space. Real windows always have a Space.
@@ -233,7 +260,14 @@ enum WindowEnumerator {
                 // server has ordered out (Stage Manager off-stage). With Stage
                 // Manager off that signature is a closed Settings/Preferences
                 // leftover, so it only survives while Stage Manager is on.
-                guard ax.axBacked.contains(w.id), stageManager else { return nil }
+                //
+                // Stage Manager suspends AX entirely for whichever app isn't the
+                // current stage, so a real off-stage window can report zero live
+                // AX windows too — indistinguishable from a closed one by
+                // ax.axBacked alone. wasEverAXBacked remembers that this id was
+                // confirmed real earlier in the session, so it survives being
+                // temporarily un-inspectable while off-stage.
+                guard (ax.axBacked.contains(w.id) || wasEverAXBacked(w.id)), stageManager else { return nil }
                 out.isCrossSpace = false
                 return out
             }
@@ -363,7 +397,15 @@ enum WindowEnumerator {
                 width: boundsDict["Width"] ?? 0,
                 height: boundsDict["Height"] ?? 0
             )
-            if bounds.width < 100 || bounds.height < 80 { continue }
+            // Stage Manager reports garbage/degenerate bounds for a real window
+            // while it's off-stage (observed: a titled window's bounds fluctuating
+            // between e.g. 112x102 and 78x109 across successive queries). A titled
+            // window is essentially never the tooltip/overlay junk this minimum-size
+            // check exists to catch, so only enforce it here when title is empty or
+            // Stage Manager is off.
+            if bounds.width < 100 || bounds.height < 80 {
+                if title.isEmpty || !stageManagerEnabled { continue }
+            }
             if title.isEmpty && titlesReliable
                 && (bounds.width < 400 || bounds.height < 300) { continue }
             // Dedupe by CGWindowID only — it's already unique per window.

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -186,7 +186,6 @@ enum WindowEnumerator {
                 if _AXUIElementGetWindow(ax, &id) == .success, id != 0 {
                     axBacked.insert(id)
                     AXWindowCache.store(ax, for: id)
-                    rememberAXBacked(id)
                     var minRef: CFTypeRef?
                     if AXUIElementCopyAttributeValue(ax, kAXMinimizedAttribute as CFString, &minRef) == .success,
                        let isMin = minRef as? Bool, isMin {
@@ -195,6 +194,7 @@ enum WindowEnumerator {
                 }
             }
         }
+        rememberAXBacked(axBacked)
         return (axBacked, minimized)
     }
 
@@ -204,9 +204,9 @@ enum WindowEnumerator {
     private static let axEverSeenLock = NSLock()
     private static var axEverSeen: Set<CGWindowID> = []
 
-    private static func rememberAXBacked(_ id: CGWindowID) {
+    private static func rememberAXBacked(_ ids: Set<CGWindowID>) {
         axEverSeenLock.lock(); defer { axEverSeenLock.unlock() }
-        axEverSeen.insert(id)
+        axEverSeen.formUnion(ids)
     }
 
     private static func wasEverAXBacked(_ id: CGWindowID) -> Bool {
@@ -386,12 +386,8 @@ enum WindowEnumerator {
                 width: boundsDict["Width"] ?? 0,
                 height: boundsDict["Height"] ?? 0
             )
-            // Stage Manager reports garbage/degenerate bounds for a real window
-            // while it's off-stage (observed: a titled window's bounds fluctuating
-            // between e.g. 112x102 and 78x109 across successive queries). A titled
-            // window is essentially never the tooltip/overlay junk this minimum-size
-            // check exists to catch, so only enforce it here when title is empty or
-            // Stage Manager is off.
+            // Stage Manager reports garbage bounds for real off-stage windows,
+            // so skip the size check for titled ones (untitled junk still caught).
             if bounds.width < 100 || bounds.height < 80 {
                 if title.isEmpty || !stageManagerEnabled { continue }
             }

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -255,8 +255,10 @@ enum WindowEnumerator {
             let spaces = CGSCopySpacesForWindows(cid, 7, arr)?.takeRetainedValue() as? [Int] ?? []
             if spaces.isEmpty {
                 // No Space, never AX-backed = ghost. AX-backed now or before = real
-                // window Stage Manager parked off-stage.
-                guard stageManager, ax.axBacked.contains(w.id) || wasEverAXBacked(w.id) else { return nil }
+                // window Stage Manager parked off-stage. (axWindowState already
+                // folds the current axBacked set into the ever-seen cache, so
+                // checking wasEverAXBacked alone covers both cases.)
+                guard stageManager, wasEverAXBacked(w.id) else { return nil }
                 out.isCrossSpace = false
                 return out
             }
@@ -363,6 +365,7 @@ enum WindowEnumerator {
                 }
             }
         }
+        let stageManager = stageManagerEnabled
         var out: [WindowInfo] = []
         var seenIDs: Set<CGWindowID> = []
         let titlesReliable = CGPreflightScreenCaptureAccess()
@@ -389,7 +392,7 @@ enum WindowEnumerator {
             // Stage Manager reports garbage bounds for real off-stage windows,
             // so skip the size check for titled ones (untitled junk still caught).
             if bounds.width < 100 || bounds.height < 80 {
-                if title.isEmpty || !stageManagerEnabled { continue }
+                if title.isEmpty || !stageManager { continue }
             }
             if title.isEmpty && titlesReliable
                 && (bounds.width < 400 || bounds.height < 300) { continue }


### PR DESCRIPTION
Fixes #99

## Problem

With Stage Manager on, an app with a real open window but isn't the current stage gets misdetected as windowless.

## Root cause

- Off-stage apps have their AX tree suspended — `kAXWindowsAttribute` returns zero windows until the app is activated again (verified directly against Reminders, independent of Switch).
- `annotateAndPrune`'s off-stage branch only keeps a window if it's *currently* AX-backed, so it always prunes off-stage windows as ghosts.
- `CGWindowListCopyWindowInfo` also reports fluctuating, often sub-100px bounds for the same off-stage window across queries, which can trip the min-size filter in `enumerate(option:)`.

## Fix

- Remember every `CGWindowID` once confirmed AX-backed (`axEverSeen`), purged only when it disappears from `CGWindowList` entirely (i.e. actually closed). The off-stage check now accepts `wasEverAXBacked(w.id)` (this already covers "currently AX-backed" too, since `axWindowState` folds the current set into the cache before this check runs).
- Only relax the min-size filter for **titled** windows when Stage Manager is on (untitled-window filtering is untouched).

## Testing

Built and manually tested on the machine that hit the bug, across several rounds:

- Reminders/Finder now show correctly as normal windows when off-stage, instead of "NO WINDOWS."
- Caught and fixed a regression mid-testing: an initial title-matching approach (via the app's Window menu) caused duplicate Zoom/Mail/Chrome/Claude entries. Reverted to the id-based cache above, which doesn't have that problem — see code comment for why.
- Re-verified after the revert and after a follow-up simplification pass (batching the cache update, removing a redundant condition, hoisting a per-window UserDefaults read out of a loop): no duplicates, off-stage detection still correct.

Not tested: other Stage Manager transition states beyond direct manual repro (many off-stage apps at once, rapid stage-switching).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes off-stage Stage Manager windows being misdetected as windowless by introducing an `axEverSeen` cache — a `Set<CGWindowID>` that remembers every window ID confirmed AX-backed, purged only when the ID disappears from all `CGWindowList` sweeps (i.e. the window is actually closed, not just parked off-stage). It also relaxes the 100×80 bounds filter for titled windows when Stage Manager is active, since the window server reports garbage geometry for off-stage windows.

- Adds `axEverSeen` / `axEverSeenLock` with `rememberAXBacked`, `wasEverAXBacked`, and `purgeAXEverSeen` helpers; `annotateAndPrune`'s empty-spaces branch now checks `wasEverAXBacked` instead of the current-sweep `ax.axBacked` set.
- Relaxes the minimum-size filter in `enumerate(option:)` to pass titled windows through when Stage Manager is enabled, guarding against fluctuating sub-100 px bounds reported for real off-stage windows.

<h3>Confidence Score: 5/5</h3>

- Safe to merge. The `axEverSeen` cache is correctly bounded (purged when IDs leave all CGWindowList sweeps), thread-safe via `NSLock`, and falls back gracefully when Stage Manager is off — the new code path is gated by `stageManager` so non-Stage-Manager behavior is unchanged.
- The fix is well-scoped: a persistent window-ID cache that is correctly populated before `annotateAndPrune` reads it, and correctly drained when windows close. The bounds-filter relaxation is tight (only titled windows, only under Stage Manager). The pre-existing `stageManagerEnabled` read-race (three independent reads per sweep) is a one-sweep edge case on SM toggle that was already flagged before this PR and does not block merging.
- No files require special attention. The only changed file is `WindowEnumerator.swift`, and the new helpers are straightforward and self-contained.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Sources/Switch/WindowEnumerator.swift | Adds an `axEverSeen` cache (guarded by `NSLock`) to track window IDs confirmed AX-backed across sweeps, relaxes the bounds filter for titled windows under Stage Manager, and fixes off-stage windows being misdetected as windowless. The pre-existing `stageManagerEnabled` read-race (three independent reads per sweep) is not addressed by this PR. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant FS as fullSnapshot()
    participant EO as enumerate(option:)
    participant AX as axWindowState()
    participant AES as axEverSeen cache
    participant AP as annotateAndPrune()
    participant PAES as purgeAXEverSeen()

    FS->>EO: "enumerate(.optionOnScreenOnly)<br/>reads stageManagerEnabled #1"
    EO-->>FS: onScreen [WindowInfo]

    FS->>EO: "enumerate(.optionAll)<br/>reads stageManagerEnabled #2"
    EO-->>FS: everything [WindowInfo]

    FS->>AX: axWindowState(for: pids)
    AX->>AES: rememberAXBacked(axBacked) — union current IDs
    AX-->>FS: (axBacked, minimized)

    FS->>FS: "reads stageManagerEnabled #3"
    FS->>AP: "annotateAndPrune(stageManager: #3)"
    AP->>AES: wasEverAXBacked(id) — for empty-space windows
    AES-->>AP: true/false
    AP-->>FS: annotated [WindowInfo]

    FS->>PAES: purgeAXEverSeen(keeping: allEnumeratedIDs)
    PAES->>AES: formIntersection — evict closed windows
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Drop redundant ax.axBacked check; hoist ..."](https://github.com/sanyam-g/switch/commit/0ac7e278d22b035bf69ca8f78ff05d29a21cba9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47782710)</sub>

<!-- /greptile_comment -->