### PR TITLE
Add secondary All windows shortcut

### DIFF
--- a/Sources/Switch/HotkeyConfig.swift
+++ b/Sources/Switch/HotkeyConfig.swift
@@ -61,6 +61,7 @@ final class HotkeyConfig {
 
     private let defaults = UserDefaults.standard
     private let allKey = "switch.hotkey.allWindows"
+    private let secondaryAllKey = "switch.hotkey.secondaryAllWindows"
     private let appKey = "switch.hotkey.currentApp"
     private let spacesKey = "switch.hotkey.spaces"
     private let stickyKey = "switch.hotkey.stickyToggle"
@@ -68,6 +69,7 @@ final class HotkeyConfig {
 
     private let lock = NSLock()
     private var cachedAll: HotkeyBinding?
+    private var cachedSecondaryAll: HotkeyBinding?
     private var cachedApp: HotkeyBinding?
     private var cachedSpaces: HotkeyBinding?
     private var cachedSticky: HotkeyBinding?
@@ -83,6 +85,7 @@ final class HotkeyConfig {
             defaults.set(true, forKey: seededKey)
         }
         cachedAll = load(allKey)
+        cachedSecondaryAll = load(secondaryAllKey)
         cachedApp = load(appKey)
         cachedSpaces = load(spacesKey)
         cachedSticky = load(stickyKey)
@@ -91,6 +94,11 @@ final class HotkeyConfig {
     var allWindows: HotkeyBinding? {
         get { lock.lock(); defer { lock.unlock() }; return cachedAll }
         set { store(newValue, key: allKey) { self.cachedAll = newValue } }
+    }
+
+    var secondaryAllWindows: HotkeyBinding? {
+        get { lock.lock(); defer { lock.unlock() }; return cachedSecondaryAll }
+        set { store(newValue, key: secondaryAllKey) { self.cachedSecondaryAll = newValue } }
     }
 
     var currentApp: HotkeyBinding? {
@@ -111,10 +119,12 @@ final class HotkeyConfig {
     func resetToDefaults() {
         write(.defaultAllWindows, key: allKey)
         write(.defaultCurrentApp, key: appKey)
+        defaults.removeObject(forKey: secondaryAllKey)
         defaults.removeObject(forKey: spacesKey)
         defaults.removeObject(forKey: stickyKey)
         lock.lock()
         cachedAll = .defaultAllWindows
+        cachedSecondaryAll = nil
         cachedApp = .defaultCurrentApp
         cachedSpaces = nil
         cachedSticky = nil
@@ -160,10 +170,13 @@ enum HotkeyValidator {
     ]
 
     /// Returns nil if the combo is allowed; otherwise a short human reason.
-    static func reject(keyCode: UInt16, flags: CGEventFlags) -> String? {
+    static func reject(keyCode: UInt16, flags: CGEventFlags, allowBare: Bool = false) -> String? {
         let mask: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
         let cleaned = flags.intersection(mask)
-        if cleaned.intersection([.maskCommand, .maskAlternate, .maskControl]).rawValue == 0 {
+        if cleaned.intersection([.maskCommand, .maskAlternate, .maskControl]).rawValue == 0,
+           !(allowBare
+             && cleaned.rawValue == 0
+             && [105, 107, 113, 106, 64, 79, 80, 90].contains(keyCode)) {
             return "Needs at least one modifier (⌘, ⌥, or ⌃)."
         }
         for (rk, rf) in reserved where rk == keyCode && rf == cleaned {
@@ -194,7 +207,9 @@ enum KeyName {
         123: "←", 124: "→", 125: "↓", 126: "↑",
         122: "F1", 120: "F2", 99: "F3", 118: "F4",
         96: "F5", 97: "F6", 98: "F7", 100: "F8",
-        101: "F9", 109: "F10", 103: "F11", 111: "F12"
+        101: "F9", 109: "F10", 103: "F11", 111: "F12",
+        105: "F13", 107: "F14", 113: "F15", 106: "F16",
+        64: "F17", 79: "F18", 80: "F19", 90: "F20"
     ]
 
     private static func chars(for code: UInt16) -> String? {

--- a/Sources/Switch/HotkeyManager.swift
+++ b/Sources/Switch/HotkeyManager.swift
@@ -27,6 +27,7 @@ final class HotkeyManager {
     private var armed: Mode?
     private var armedAt: Date?
     private var advanced = false
+    private var forcePickerOpen = false
     private var lastShift = false
     private var suspended = false
     private var stopRequested = false
@@ -225,6 +226,7 @@ final class HotkeyManager {
 
         if type == .keyDown {
             let allBinding = HotkeyConfig.shared.allWindows
+            let secondaryAllBinding = HotkeyConfig.shared.secondaryAllWindows
             let appBinding = HotkeyConfig.shared.currentApp
             let spacesBinding = HotkeyConfig.shared.spaces
 
@@ -236,6 +238,10 @@ final class HotkeyManager {
                 return nil
             }
 
+            if let secondaryAllBinding, secondaryAllBinding.matchesTrigger(keyCode: kc, flags: flags) {
+                armOrAdvance(.allWindows, shift: shift, forceOpen: true)
+                return nil
+            }
             if let allBinding, allBinding.matchesTrigger(keyCode: kc, flags: flags) {
                 armOrAdvance(.allWindows, shift: shift)
                 return nil
@@ -251,12 +257,14 @@ final class HotkeyManager {
 
             stateLock.lock()
             let armedMode = armed
+            let forcedOpen = forcePickerOpen
             stateLock.unlock()
 
             if let mode = armedMode {
-                let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
+                let storedStickyPreference = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
+                let effectiveSticky = storedStickyPreference || forcedOpen
                 let typeToFilter = (UserDefaults.standard.object(forKey: SwitchPreferences.typeToFilterKey) as? Bool) ?? true
-                let actionModifierMatches = cmd && (sticky || !typeToFilter || shift)
+                let actionModifierMatches = cmd && (effectiveSticky || !typeToFilter || shift)
                 if kc == Self.kcEscape {
                     clearArmed()
                     DispatchQueue.main.async { [weak self] in
@@ -271,7 +279,7 @@ final class HotkeyManager {
                     }
                     return nil
                 }
-                if !sticky && !armingModifiersHeld(mode, flags) {
+                if !effectiveSticky && !armingModifiersHeld(mode, flags) {
                     clearArmed()
                     DispatchQueue.main.async { [weak self] in
                         self?.onCommit?()
@@ -354,9 +362,10 @@ final class HotkeyManager {
             }
 
             if !armingHeld {
-                let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
+                let storedStickyPreference = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
+                let effectiveSticky = storedStickyPreference || forcePickerOpen
                 let quickTap = (armedAt.map { Date().timeIntervalSince($0) * 1000 < Self.stickyQuickTapMS } ?? false) && !advanced
-                if !sticky || quickTap {
+                if !effectiveSticky || (!forcePickerOpen && quickTap) {
                     clearArmedLocked()
                     stateLock.unlock()
                     DispatchQueue.main.async { [weak self] in
@@ -372,13 +381,14 @@ final class HotkeyManager {
         return Unmanaged.passUnretained(event)
     }
 
-    private func armOrAdvance(_ mode: Mode, shift: Bool) {
+    private func armOrAdvance(_ mode: Mode, shift: Bool, forceOpen: Bool = false) {
         stateLock.lock()
         let isFirst = armed == nil
         if isFirst {
             armed = mode
             armedAt = Date()
             advanced = false
+            forcePickerOpen = forceOpen
         } else {
             advanced = true
         }
@@ -408,6 +418,7 @@ final class HotkeyManager {
         armed = nil
         armedAt = nil
         advanced = false
+        forcePickerOpen = false
     }
 
     func clearArmed() {
@@ -430,11 +441,13 @@ final class HotkeyManager {
             stateLock.unlock()
             return
         }
+        let forcedOpen = forcePickerOpen
         stateLock.unlock()
-        let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
-        guard !sticky, !armingModifiersHeld(mode, hardware) else { return }
+        let storedStickyPreference = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
+        let effectiveSticky = storedStickyPreference || forcedOpen
+        guard !effectiveSticky, !armingModifiersHeld(mode, hardware) else { return }
         stateLock.lock()
-        guard armed == mode, armedAt == at else {
+        guard armed == mode, armedAt == at, forcePickerOpen == forcedOpen else {
             stateLock.unlock()
             return
         }

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -7,6 +7,7 @@ import ServiceManagement
 final class SettingsModel: ObservableObject {
     @Published var launchAtLogin: Bool = false
     @Published var allWindows: HotkeyBinding? = HotkeyConfig.shared.allWindows
+    @Published var secondaryAllWindows: HotkeyBinding? = HotkeyConfig.shared.secondaryAllWindows
     @Published var currentApp: HotkeyBinding? = HotkeyConfig.shared.currentApp
     @Published var spaces: HotkeyBinding? = HotkeyConfig.shared.spaces
     @Published var stickyToggle: HotkeyBinding? = HotkeyConfig.shared.stickyToggle
@@ -18,6 +19,7 @@ final class SettingsModel: ObservableObject {
             launchAtLogin = SMAppService.mainApp.status == .enabled
         }
         allWindows = HotkeyConfig.shared.allWindows
+        secondaryAllWindows = HotkeyConfig.shared.secondaryAllWindows
         currentApp = HotkeyConfig.shared.currentApp
         spaces = HotkeyConfig.shared.spaces
         stickyToggle = HotkeyConfig.shared.stickyToggle
@@ -42,6 +44,11 @@ final class SettingsModel: ObservableObject {
     func updateAllWindows(_ b: HotkeyBinding?) {
         HotkeyConfig.shared.allWindows = b
         allWindows = b
+    }
+
+    func updateSecondaryAllWindows(_ b: HotkeyBinding?) {
+        HotkeyConfig.shared.secondaryAllWindows = b
+        secondaryAllWindows = b
     }
 
     func updateCurrentApp(_ b: HotkeyBinding?) {
@@ -84,6 +91,8 @@ struct SettingsView: View {
     @ObservedObject private var prefs = SwitchPreferences.shared
     @State private var rejectMessage: String?
     @State private var tab: SettingsTab = .general
+    @State private var secondaryHotkeyExpanded = false
+    @State private var showSecondaryHotkeyWhy = false
     @State private var draggedApp: String?
     @State private var openWindows: [WindowInfo] = []
 
@@ -153,6 +162,50 @@ struct SettingsView: View {
                         hotkeyRow(label: "All windows", binding: model.allWindows) { b in
                             applyHotkey(b) { model.updateAllWindows($0) }
                         }
+                        DisclosureGroup(isExpanded: Binding(
+                            get: { model.secondaryAllWindows != nil || secondaryHotkeyExpanded },
+                            set: { if model.secondaryAllWindows == nil { secondaryHotkeyExpanded = $0 } }
+                        )) {
+                            hotkeyRow(label: "", binding: model.secondaryAllWindows,
+                                      detail: "Supports modifier combinations and bare F13-F20.") { b in
+                                applyHotkey(b, allowBare: true) { model.updateSecondaryAllWindows($0) }
+                            }
+                            .padding(.top, 8)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Secondary shortcut")
+                                    .font(.system(size: 13, weight: .medium))
+                                HStack(spacing: 4) {
+                                    Text("Optional shortcut that always keeps the All windows picker open.")
+                                        .font(.system(size: 11))
+                                        .foregroundStyle(.secondary)
+                                    Button("Why?") {
+                                        showSecondaryHotkeyWhy = true
+                                    }
+                                    .buttonStyle(.plain)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(prefs.accent.color)
+                                    .onHover { hovering in
+                                        if hovering { showSecondaryHotkeyWhy = true }
+                                    }
+                                    .popover(isPresented: $showSecondaryHotkeyWhy, arrowEdge: .bottom) {
+                                        Text("Useful with gesture and remapping tools. For example, map a BetterTouchTool three-finger Force Click to F14, then assign F14 here to open the picker without holding a keyboard shortcut.")
+                                            .font(.system(size: 12))
+                                            .fixedSize(horizontal: false, vertical: true)
+                                            .frame(width: 280, alignment: .leading)
+                                            .padding(12)
+                                    }
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                if model.secondaryAllWindows == nil {
+                                    secondaryHotkeyExpanded.toggle()
+                                }
+                            }
+                        }
+                        .tint(prefs.accent.color)
                         hotkeyRow(label: "Current app", binding: model.currentApp) { b in
                             applyHotkey(b) { model.updateCurrentApp($0) }
                         }
@@ -785,13 +838,13 @@ struct SettingsView: View {
         }
     }
 
-    private func applyHotkey(_ b: HotkeyBinding?, save: (HotkeyBinding?) -> Void) {
+    private func applyHotkey(_ b: HotkeyBinding?, allowBare: Bool = false, save: (HotkeyBinding?) -> Void) {
         guard let b else {
             rejectMessage = nil
             save(nil)
             return
         }
-        if let msg = HotkeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags) {
+        if let msg = HotkeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags, allowBare: allowBare) {
             rejectMessage = msg
         } else {
             rejectMessage = nil


### PR DESCRIPTION
**AI disclosure: I used GPT-5.6 Sol Ultra to help plan and implement this change. I reviewed the diff and manually tested the resulting behavior, and I'm posting this PR myself as a human, not a bot.**

I wanted to trigger Switch entirely from the trackpad whenever my laptop was undocked. BetterTouchTool can map a three-finger Force Click to ⌘-Tab, but the synthetic shortcut is only a quick press. Switch interprets that as a quick tap and immediately toggles between windows. A gesture that holds a three-finger Force Click while moving the pointer to choose a window isn't practical.

I also wanted to preserve the keyboard shortcut's existing quick-switch behavior, so enabling Sticky picker globally wasn't a good fit. This PR adds an optional secondary All windows shortcut that always leaves the picker open. It accepts bare F13-F20 keys, which gives BetterTouchTool a dedicated trigger that won't conflict with a typical physical keyboard (since most physical keyboards don't have these keys).

The implementation adds one optional binding and one forced-open session flag, then reuses the existing All windows flow.

**Changes:**

- Adds a persisted, unset-by-default secondary All windows binding that Reset Hotkeys clears.
- Allows bare F13-F20 only for the secondary binding. Existing hotkey validation remains unchanged.
- Keeps secondary sessions open until the existing commit or cancellation paths resolve them.
- Adds a compact disclosure beneath All windows, including the remapping use case in a Why? popover.
- Preserves the stock primary shortcut, Sticky picker, and quick-tap behavior.

**Tested:**

- Built from a clean generated Xcode project with `xcodebuild` in the Debug configuration for macOS.
- Verified the ad hoc app signature with `codesign --verify --deep --strict`.
- Manually verified primary quick-tap and Sticky picker behavior.
- Manually verified the secondary shortcut with Sticky picker enabled and disabled.
- Verified the disclosure row and immediate Why? popover interactions.
- Ran `git diff --check`.

**Visual:**

- Default (Unselected, Collapsed)
<img width="1348" height="1332" alt="CleanShot 2026-07-10 at 16 10 26@2x" src="https://github.com/user-attachments/assets/732b42b2-9c05-49e9-9a52-3d4cf7c2ee76" />


- Selected, Expanded
<img width="1348" height="1332" alt="CleanShot 2026-07-10 at 16 11 10@2x" src="https://github.com/user-attachments/assets/449a6637-8efe-4420-8dee-cc077a064ac0" />

- Tooltip to Explain Usefulness
<img width="1656" height="1556" alt="CleanShot 2026-07-10 at 16 11 19@2x" src="https://github.com/user-attachments/assets/04a2e85a-204b-4052-ae56-3203bad5d3c5" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional secondary "All windows" hotkey that always opens the picker in sticky/force-open mode, designed for use with gesture remapping tools (e.g. BetterTouchTool mapping a three-finger Force Click to a bare F-key). The implementation adds a new `forcePickerOpen` flag in `HotkeyManager` that propagates through all the armed-session exit paths, preserving the primary binding's quick-switch behaviour untouched.

- **`HotkeyConfig`**: Adds a new `secondaryAllWindows` binding stored under its own `UserDefaults` key, loaded and cached with the existing lock pattern, and cleared by `resetToDefaults`.
- **`HotkeyManager`**: Checks the secondary binding before the primary in `handle()`; when matched, arms with `forceOpen: true`, which is respected in `keyDown`, `flagsChanged`, and `recoverIfReleaseWasMissed` to prevent the picker from auto-dismissing.
- **`SettingsView`**: Adds a collapsible `DisclosureGroup` beneath the primary All windows row with a "Why?" popover, wired to `applyHotkey(allowBare: true)` so bare F13–F20 keys pass validation.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the BetterTouchTool use case, but the secondary binding can silently override the primary's quick-switch behaviour if both are set to the same hotkey.

The forcePickerOpen flag is correctly propagated through every armed-session exit path (keyDown, flagsChanged, recoverIfReleaseWasMissed), and the locking is consistent with the rest of the codebase. The material risk is that the secondary binding is evaluated before the primary with no cross-binding conflict check. A user who accidentally records ⌘Tab into the secondary field (Tab is not in the reserved list, so the validator accepts it) will find that every ⌘Tab press enters force-open mode, permanently disabling quick-switch with no error shown. This is a live behavioural regression for the primary shortcut triggered by a single mistaken key capture.

**Files Needing Attention:** HotkeyManager.swift — the secondary-before-primary check order combined with the missing conflict guard is where the risk lives. HotkeyConfig.swift and SettingsView.swift are straightforward.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Sources/Switch/HotkeyConfig.swift | Adds secondaryAllWindows binding with correct lock usage, UserDefaults persistence, and reset behaviour. F13–F20 key codes and validator allowBare flag are logically correct. No new threading issues introduced. |
| Sources/Switch/HotkeyManager.swift | forcePickerOpen flag is accessed correctly under stateLock throughout. Logic for effectiveSticky in keyDown, flagsChanged, and recoverIfReleaseWasMissed is sound. Key issue: secondary binding is checked before primary with no conflict guard, so an identical combo silently overrides quick-switch behaviour. |
| Sources/Switch/SettingsView.swift | DisclosureGroup binding logic, refresh/update paths, and allowBare propagation are well-structured. Minor UX issue: disclosure chevron appears interactive but is a no-op while a secondary binding is configured. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant BTT as BetterTouchTool / User
    participant HM as HotkeyManager (CGEventTap)
    participant HC as HotkeyConfig
    participant UI as Picker UI

    BTT->>HM: keyDown F14 (secondary binding)
    HM->>HC: secondaryAllWindows?
    HC-->>HM: HotkeyBinding(F14, no modifiers)
    HM->>HM: armOrAdvance(.allWindows, forceOpen: true)
    Note over HM: armed=.allWindows, forcePickerOpen=true
    HM->>UI: onArm(.allWindows)
    UI-->>BTT: Picker appears (force-open)

    BTT->>HM: keyDown ↓ (arrow navigate)
    HM->>UI: onNavigate(.down)

    BTT->>HM: keyDown Return / Escape
    HM->>HM: "clearArmed() → forcePickerOpen=false"
    HM->>UI: onCommit / onCancel
    UI-->>BTT: Picker dismissed

    Note over HM: flagsChanged (modifier key release) with forcePickerOpen=true
    HM->>HM: "effectiveSticky=true → skip auto-dismiss"
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/Switch/HotkeyManager.swift`, line 241-248 ([link](https://github.com/sanyam-g/switch/blob/b4c1653c0e8521e3e149c94c8ea8fe590401cfdd/Sources/Switch/HotkeyManager.swift#L241-L248)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Secondary binding silently overrides primary with no conflict guard**

   The secondary binding check is placed before the primary in `handle()` and always arms with `forceOpen: true`. If a user accidentally records the same combo for both (e.g. ⌘Tab into the secondary field — Tab is not in the `reserved` list, so the validator accepts it), every future press of that key enters force-open mode. The quick-tap-to-switch behavior is silently lost for that combo with no warning anywhere in the UI or the validator. The `HotkeyValidator.reject` call for the secondary path does not compare against the stored `allWindows`, `currentApp`, `spaces`, or `stickyToggle` bindings.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Add secondary All windows shortcut"](https://github.com/sanyam-g/switch/commit/b4c1653c0e8521e3e149c94c8ea8fe590401cfdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47782709)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->