### PR TITLE
Added CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# **Contributing to Switch**
+
+Thank you for your interest in contributing to Switch. To maintain quality, consistency, and efficient codebase administration, please review the following guidelines before submitting any work.
+
+## **Core Rules & Contribution Policy**
+
+To ensure a healthy and maintainable codebase, the project operates under a strict **"issue first, hand-written changes only"** policy.
+
+* **Open an Issue First:** An issue must be opened to describe the feature, enhancement, or bug before starting on any code changes.  
+* **Hand-Written Changes Only:** All submitted pull requests must consist of code and descriptions written directly by the contributor.
+
+Fully AI-generated pull requests are not accepted and will be closed without review. While feature ideas from such submissions are welcome, the actual code will not be merged. Contributors are expected to understand all code they submit and be prepared to support their changes.
+
+## **Workflow**
+
+1. Open an issue to describe the feature, enhancement, or bug.  
+2. Reference the issue number in the pull request description (e.g., Closes \#104).  
+3. Working on an issue does not require explicit assignment or a reply—pull requests may be opened directly after the corresponding issue is created.
+
+## **Reporting Issues**
+
+If a bug is found or a feature is requested, please open an issue. To assist with diagnosing bugs or troubleshooting, relevant system details should be included in the report.
+
+### **Required Troubleshooting Specs:**
+
+* **Operating System:** Exact macOS version (e.g., macOS Sonoma 14.4).  
+* **Hardware Architecture:** Intel or Apple Silicon (M1/M2/M3).  
+* **Steps to Reproduce:** Clear, numbered instructions showing how to trigger the issue.  
+* **Expected vs. Actual Behavior:** What should have happened versus what actually occurred.  
+* **Logs/Screenshots:** Relevant terminal outputs, crash logs, or visual errors, if applicable.
+
+## **Pull Request Guidelines**
+
+* **Branching:** Use descriptive feature branches (e.g., feature/issue-104-fix) instead of committing directly to main.  
+* **Code Style:** Match the existing Swift formatting conventions present in the codebase.  
+* **Testing:** Verify changes locally to ensure they do not introduce regressions or break existing configurations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,21 @@
 # **Contributing to Switch**
 
-Thank you for your interest in contributing to Switch. To maintain quality, consistency, and efficient codebase administration, please review the following guidelines before submitting any work.
+Thank you for your interest in contributing to Switch.
 
 ## **Core Rules & Contribution Policy**
 
-To ensure a healthy and maintainable codebase, the project operates under a strict **"issue first, hand-written changes only"** policy.
+* **Open an Issue First:** It is recommended that an issue be opened to describe the feature, enhancement, or bug before starting on any code changes.  
+* **Hand-Written Changes:** All submitted pull requests must consist of descriptions written directly by the contributor.
 
-* **Open an Issue First:** An issue must be opened to describe the feature, enhancement, or bug before starting on any code changes.  
-* **Hand-Written Changes Only:** All submitted pull requests must consist of code and descriptions written directly by the contributor.
-
-Fully AI-generated pull requests are not accepted and will be closed without review. While feature ideas from such submissions are welcome, the actual code will not be merged. Contributors are expected to understand all code they submit and be prepared to support their changes.
+While feature ideas from such submissions are welcome, fully AI-generated pull requests will be closed without review, the actual code will not be merged.
 
 ## **Workflow**
 
 1. Open an issue to describe the feature, enhancement, or bug.  
 2. Reference the issue number in the pull request description (e.g., Closes \#104).  
-3. Working on an issue does not require explicit assignment or a reply—pull requests may be opened directly after the corresponding issue is created.
-
-## **Reporting Issues**
-
-If a bug is found or a feature is requested, please open an issue. To assist with diagnosing bugs or troubleshooting, relevant system details should be included in the report.
-
-### **Required Troubleshooting Specs:**
-
-* **Operating System:** Exact macOS version (e.g., macOS Sonoma 14.4).  
-* **Hardware Architecture:** Intel or Apple Silicon (M1/M2/M3).  
-* **Steps to Reproduce:** Clear, numbered instructions showing how to trigger the issue.  
-* **Expected vs. Actual Behavior:** What should have happened versus what actually occurred.  
-* **Logs/Screenshots:** Relevant terminal outputs, crash logs, or visual errors, if applicable.
+3. Working on an issue does not require explicit assignment or a reply, pull requests may be opened directly after the issue is created.
 
 ## **Pull Request Guidelines**
 
 * **Branching:** Use descriptive feature branches (e.g., feature/issue-104-fix) instead of committing directly to main.  
 * **Code Style:** Match the existing Swift formatting conventions present in the codebase.  
-* **Testing:** Verify changes locally to ensure they do not introduce regressions or break existing configurations.


### PR DESCRIPTION
I've added a `CONTRIBUTING.md` file with basic contribution guidance, including:

- Coding/style expectations for Swift code changes
- Commit/PR submission guidelines
- A simple issue/feature request workflow

This is an initial draft to make contributing easier and can be expanded over time.

Fixes: #104 