### PR TITLE
Keep picker open and add alternate hotkeys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,16 @@ Thank you for your interest in contributing to Switch.
 * **Open an Issue First:** It is recommended that an issue be opened to describe the feature, enhancement, or bug before starting on any code changes.  
 * **Hand-Written Changes:** All submitted pull requests must consist of descriptions written directly by the contributor.
 
-While feature ideas from such submissions are welcome, fully AI-generated pull requests will be closed without review, the actual code will not be merged.
+I'll take feature ideas from AI-generated PRs, but I won't merge them. Hand-written PRs are welcome.
 
-## **Workflow**
+## **Recommended Workflow**
 
 1. Open an issue to describe the feature, enhancement, or bug.  
 2. Reference the issue number in the pull request description (e.g., Closes \#104).  
-3. Working on an issue does not require explicit assignment or a reply, pull requests may be opened directly after the issue is created.
+3. Feel free to work on any issue you want to fix!
 
 ## **Pull Request Guidelines**
 
 * **Branching:** Use descriptive feature branches (e.g., feature/issue-104-fix) instead of committing directly to main.  
 * **Code Style:** Match the existing Swift formatting conventions present in the codebase.  
+* And please test out your changes! A screenshot of any visual changes would be great too!

--- a/Sources/Switch/HotkeyConfig.swift
+++ b/Sources/Switch/HotkeyConfig.swift
@@ -44,6 +44,12 @@ struct HotkeyBinding: Codable, Equatable {
         return flags.intersection(mask) == needNeeded
     }
 
+    func conflicts(with other: HotkeyBinding) -> Bool {
+        let mask: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl]
+        return keyCode == other.keyCode
+            && cgFlags.intersection(mask) == other.cgFlags.intersection(mask)
+    }
+
     var displayString: String {
         var s = ""
         if cgFlags.contains(.maskControl) { s += "⌃" }
@@ -61,15 +67,21 @@ final class HotkeyConfig {
 
     private let defaults = UserDefaults.standard
     private let allKey = "switch.hotkey.allWindows"
+    private let allAlternateKey = "switch.hotkey.allWindows.alternate"
     private let appKey = "switch.hotkey.currentApp"
+    private let appAlternateKey = "switch.hotkey.currentApp.alternate"
     private let spacesKey = "switch.hotkey.spaces"
+    private let spacesAlternateKey = "switch.hotkey.spaces.alternate"
     private let stickyKey = "switch.hotkey.stickyToggle"
     private let seededKey = "switch.hotkey.seeded"
 
     private let lock = NSLock()
     private var cachedAll: HotkeyBinding?
+    private var cachedAllAlternate: HotkeyBinding?
     private var cachedApp: HotkeyBinding?
+    private var cachedAppAlternate: HotkeyBinding?
     private var cachedSpaces: HotkeyBinding?
+    private var cachedSpacesAlternate: HotkeyBinding?
     private var cachedSticky: HotkeyBinding?
 
     static let didChangeNotification = Notification.Name("com.sanyamgarg.switch.hotkeyConfigDidChange")
@@ -83,8 +95,11 @@ final class HotkeyConfig {
             defaults.set(true, forKey: seededKey)
         }
         cachedAll = load(allKey)
+        cachedAllAlternate = load(allAlternateKey)
         cachedApp = load(appKey)
+        cachedAppAlternate = load(appAlternateKey)
         cachedSpaces = load(spacesKey)
+        cachedSpacesAlternate = load(spacesAlternateKey)
         cachedSticky = load(stickyKey)
     }
 
@@ -93,14 +108,29 @@ final class HotkeyConfig {
         set { store(newValue, key: allKey) { self.cachedAll = newValue } }
     }
 
+    var allWindowsAlternate: HotkeyBinding? {
+        get { lock.lock(); defer { lock.unlock() }; return cachedAllAlternate }
+        set { store(newValue, key: allAlternateKey) { self.cachedAllAlternate = newValue } }
+    }
+
     var currentApp: HotkeyBinding? {
         get { lock.lock(); defer { lock.unlock() }; return cachedApp }
         set { store(newValue, key: appKey) { self.cachedApp = newValue } }
     }
 
+    var currentAppAlternate: HotkeyBinding? {
+        get { lock.lock(); defer { lock.unlock() }; return cachedAppAlternate }
+        set { store(newValue, key: appAlternateKey) { self.cachedAppAlternate = newValue } }
+    }
+
     var spaces: HotkeyBinding? {
         get { lock.lock(); defer { lock.unlock() }; return cachedSpaces }
         set { store(newValue, key: spacesKey) { self.cachedSpaces = newValue } }
+    }
+
+    var spacesAlternate: HotkeyBinding? {
+        get { lock.lock(); defer { lock.unlock() }; return cachedSpacesAlternate }
+        set { store(newValue, key: spacesAlternateKey) { self.cachedSpacesAlternate = newValue } }
     }
 
     var stickyToggle: HotkeyBinding? {
@@ -111,12 +141,18 @@ final class HotkeyConfig {
     func resetToDefaults() {
         write(.defaultAllWindows, key: allKey)
         write(.defaultCurrentApp, key: appKey)
+        defaults.removeObject(forKey: allAlternateKey)
+        defaults.removeObject(forKey: appAlternateKey)
         defaults.removeObject(forKey: spacesKey)
+        defaults.removeObject(forKey: spacesAlternateKey)
         defaults.removeObject(forKey: stickyKey)
         lock.lock()
         cachedAll = .defaultAllWindows
+        cachedAllAlternate = nil
         cachedApp = .defaultCurrentApp
+        cachedAppAlternate = nil
         cachedSpaces = nil
+        cachedSpacesAlternate = nil
         cachedSticky = nil
         lock.unlock()
         NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)

--- a/Sources/Switch/HotkeyManager.swift
+++ b/Sources/Switch/HotkeyManager.swift
@@ -25,6 +25,7 @@ final class HotkeyManager {
     private var tap: CFMachPort?
     private var source: CFRunLoopSource?
     private var armed: Mode?
+    private var armedBinding: HotkeyBinding?
     private var armedAt: Date?
     private var advanced = false
     private var lastShift = false
@@ -224,9 +225,12 @@ final class HotkeyManager {
         let kc = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
 
         if type == .keyDown {
-            let allBinding = HotkeyConfig.shared.allWindows
-            let appBinding = HotkeyConfig.shared.currentApp
-            let spacesBinding = HotkeyConfig.shared.spaces
+            let allBinding = [HotkeyConfig.shared.allWindows, HotkeyConfig.shared.allWindowsAlternate]
+                .compactMap { $0 }.first { $0.matchesTrigger(keyCode: kc, flags: flags) }
+            let appBinding = [HotkeyConfig.shared.currentApp, HotkeyConfig.shared.currentAppAlternate]
+                .compactMap { $0 }.first { $0.matchesTrigger(keyCode: kc, flags: flags) }
+            let spacesBinding = [HotkeyConfig.shared.spaces, HotkeyConfig.shared.spacesAlternate]
+                .compactMap { $0 }.first { $0.matchesTrigger(keyCode: kc, flags: flags) }
 
             if let stickyBinding = HotkeyConfig.shared.stickyToggle,
                stickyBinding.matchesTrigger(keyCode: kc, flags: flags) {
@@ -236,24 +240,25 @@ final class HotkeyManager {
                 return nil
             }
 
-            if let allBinding, allBinding.matchesTrigger(keyCode: kc, flags: flags) {
-                armOrAdvance(.allWindows, shift: shift)
+            if let allBinding {
+                armOrAdvance(.allWindows, binding: allBinding, shift: shift)
                 return nil
             }
-            if let spacesBinding, spacesBinding.matchesTrigger(keyCode: kc, flags: flags) {
-                armOrAdvance(.spaces, shift: shift)
+            if let spacesBinding {
+                armOrAdvance(.spaces, binding: spacesBinding, shift: shift)
                 return nil
             }
-            if let appBinding, appBinding.matchesTrigger(keyCode: kc, flags: flags) {
-                armOrAdvance(.currentApp, shift: shift)
+            if let appBinding {
+                armOrAdvance(.currentApp, binding: appBinding, shift: shift)
                 return nil
             }
 
             stateLock.lock()
             let armedMode = armed
+            let activeBinding = armedBinding
             stateLock.unlock()
 
-            if let mode = armedMode {
+            if armedMode != nil {
                 let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
                 let typeToFilter = (UserDefaults.standard.object(forKey: SwitchPreferences.typeToFilterKey) as? Bool) ?? true
                 let actionModifierMatches = cmd && (sticky || !typeToFilter || shift)
@@ -271,7 +276,7 @@ final class HotkeyManager {
                     }
                     return nil
                 }
-                if !sticky && !armingModifiersHeld(mode, flags) {
+                if !sticky && !(activeBinding?.modifiersHeld(flags) ?? false) {
                     clearArmed()
                     DispatchQueue.main.async { [weak self] in
                         self?.onCommit?()
@@ -302,7 +307,7 @@ final class HotkeyManager {
                     }
                     return nil
                 }
-                if kc == Self.kcComma && (cmd || armingModifiersHeld(mode, flags)) {
+                if kc == Self.kcComma && (cmd || activeBinding?.modifiersHeld(flags) == true) {
                     clearArmed()
                     DispatchQueue.main.async { [weak self] in
                         self?.onCancel?()
@@ -337,11 +342,11 @@ final class HotkeyManager {
             stateLock.lock()
             let shiftRising = shift && !lastShift
             lastShift = shift
-            guard let mode = armed else {
+            guard armed != nil else {
                 stateLock.unlock()
                 return Unmanaged.passUnretained(event)
             }
-            let armingHeld = armingModifiersHeld(mode, flags)
+            let armingHeld = armedBinding?.modifiersHeld(flags) ?? false
 
             if shiftRising && armingHeld
                 && UserDefaults.standard.bool(forKey: SwitchPreferences.shiftTapReversesKey) {
@@ -372,11 +377,12 @@ final class HotkeyManager {
         return Unmanaged.passUnretained(event)
     }
 
-    private func armOrAdvance(_ mode: Mode, shift: Bool) {
+    private func armOrAdvance(_ mode: Mode, binding: HotkeyBinding, shift: Bool) {
         stateLock.lock()
         let isFirst = armed == nil
         if isFirst {
             armed = mode
+            armedBinding = binding
             armedAt = Date()
             advanced = false
         } else {
@@ -388,16 +394,6 @@ final class HotkeyManager {
         }
     }
 
-    private func armingModifiersHeld(_ mode: Mode, _ flags: CGEventFlags) -> Bool {
-        let binding: HotkeyBinding?
-        switch mode {
-        case .allWindows: binding = HotkeyConfig.shared.allWindows
-        case .currentApp: binding = HotkeyConfig.shared.currentApp
-        case .spaces:     binding = HotkeyConfig.shared.spaces
-        }
-        return binding?.modifiersHeld(flags) ?? false
-    }
-
     var isArmed: Bool {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -406,6 +402,7 @@ final class HotkeyManager {
 
     private func clearArmedLocked() {
         armed = nil
+        armedBinding = nil
         armedAt = nil
         advanced = false
     }
@@ -426,15 +423,15 @@ final class HotkeyManager {
     func recoverIfReleaseWasMissed() {
         let hardware = CGEventSource.flagsState(.combinedSessionState)
         stateLock.lock()
-        guard let mode = armed, let at = armedAt else {
+        guard let mode = armed, let binding = armedBinding, let at = armedAt else {
             stateLock.unlock()
             return
         }
         stateLock.unlock()
         let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
-        guard !sticky, !armingModifiersHeld(mode, hardware) else { return }
+        guard !sticky, !binding.modifiersHeld(hardware) else { return }
         stateLock.lock()
-        guard armed == mode, armedAt == at else {
+        guard armed == mode, armedBinding == binding, armedAt == at else {
             stateLock.unlock()
             return
         }

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -7,8 +7,11 @@ import ServiceManagement
 final class SettingsModel: ObservableObject {
     @Published var launchAtLogin: Bool = false
     @Published var allWindows: HotkeyBinding? = HotkeyConfig.shared.allWindows
+    @Published var allWindowsAlternate: HotkeyBinding? = HotkeyConfig.shared.allWindowsAlternate
     @Published var currentApp: HotkeyBinding? = HotkeyConfig.shared.currentApp
+    @Published var currentAppAlternate: HotkeyBinding? = HotkeyConfig.shared.currentAppAlternate
     @Published var spaces: HotkeyBinding? = HotkeyConfig.shared.spaces
+    @Published var spacesAlternate: HotkeyBinding? = HotkeyConfig.shared.spacesAlternate
     @Published var stickyToggle: HotkeyBinding? = HotkeyConfig.shared.stickyToggle
 
     init() { refresh() }
@@ -18,8 +21,11 @@ final class SettingsModel: ObservableObject {
             launchAtLogin = SMAppService.mainApp.status == .enabled
         }
         allWindows = HotkeyConfig.shared.allWindows
+        allWindowsAlternate = HotkeyConfig.shared.allWindowsAlternate
         currentApp = HotkeyConfig.shared.currentApp
+        currentAppAlternate = HotkeyConfig.shared.currentAppAlternate
         spaces = HotkeyConfig.shared.spaces
+        spacesAlternate = HotkeyConfig.shared.spacesAlternate
         stickyToggle = HotkeyConfig.shared.stickyToggle
     }
 
@@ -44,14 +50,29 @@ final class SettingsModel: ObservableObject {
         allWindows = b
     }
 
+    func updateAllWindowsAlternate(_ b: HotkeyBinding?) {
+        HotkeyConfig.shared.allWindowsAlternate = b
+        allWindowsAlternate = b
+    }
+
     func updateCurrentApp(_ b: HotkeyBinding?) {
         HotkeyConfig.shared.currentApp = b
         currentApp = b
     }
 
+    func updateCurrentAppAlternate(_ b: HotkeyBinding?) {
+        HotkeyConfig.shared.currentAppAlternate = b
+        currentAppAlternate = b
+    }
+
     func updateSpaces(_ b: HotkeyBinding?) {
         HotkeyConfig.shared.spaces = b
         spaces = b
+    }
+
+    func updateSpacesAlternate(_ b: HotkeyBinding?) {
+        HotkeyConfig.shared.spacesAlternate = b
+        spacesAlternate = b
     }
 
     func updateStickyToggle(_ b: HotkeyBinding?) {
@@ -150,16 +171,19 @@ struct SettingsView: View {
 
                 section("Hotkeys") {
                     VStack(alignment: .leading, spacing: 12) {
-                        hotkeyRow(label: "All windows", binding: model.allWindows) { b in
-                            applyHotkey(b) { model.updateAllWindows($0) }
-                        }
-                        hotkeyRow(label: "Current app", binding: model.currentApp) { b in
-                            applyHotkey(b) { model.updateCurrentApp($0) }
-                        }
+                        hotkeyRow(label: "All windows", binding: model.allWindows,
+                                  alternate: model.allWindowsAlternate,
+                                  onCapture: { applyHotkey($0, replacing: model.allWindows) { model.updateAllWindows($0) } },
+                                  onAlternateCapture: { applyHotkey($0, replacing: model.allWindowsAlternate) { model.updateAllWindowsAlternate($0) } })
+                        hotkeyRow(label: "Current app", binding: model.currentApp,
+                                  alternate: model.currentAppAlternate,
+                                  onCapture: { applyHotkey($0, replacing: model.currentApp) { model.updateCurrentApp($0) } },
+                                  onAlternateCapture: { applyHotkey($0, replacing: model.currentAppAlternate) { model.updateCurrentAppAlternate($0) } })
                         hotkeyRow(label: "Spaces", binding: model.spaces,
-                                  detail: "Cycle Spaces. Conflicts with browser tab switching if set to ⌃Tab.") { b in
-                            applyHotkey(b) { model.updateSpaces($0) }
-                        }
+                                  alternate: model.spacesAlternate,
+                                  detail: "Cycle Spaces. Conflicts with browser tab switching if set to ⌃Tab.",
+                                  onCapture: { applyHotkey($0, replacing: model.spaces) { model.updateSpaces($0) } },
+                                  onAlternateCapture: { applyHotkey($0, replacing: model.spacesAlternate) { model.updateSpacesAlternate($0) } })
                         stickyToggleRow
                         if let msg = rejectMessage {
                             Text(msg)
@@ -450,7 +474,7 @@ struct SettingsView: View {
                 .frame(width: 100, alignment: .leading)
             KeyRecorderField(
                 initialBinding: model.stickyToggle ?? HotkeyBinding(keyCode: 0, modifiersRaw: 0),
-                onCapture: { b in apply(b) { model.updateStickyToggle($0) } },
+                onCapture: { b in applyHotkey(b, replacing: model.stickyToggle) { model.updateStickyToggle($0) } },
                 accent: prefs.accent.color,
                 placeholder: "Not set"
             )
@@ -717,22 +741,17 @@ struct SettingsView: View {
         .background(rowBackground)
     }
 
-    private func hotkeyRow(label: String, binding: HotkeyBinding?, detail: String? = nil, onCapture: @escaping (HotkeyBinding?) -> Void) -> some View {
+    private func hotkeyRow(label: String, binding: HotkeyBinding?, alternate: HotkeyBinding?, detail: String? = nil,
+                           onCapture: @escaping (HotkeyBinding?) -> Void,
+                           onAlternateCapture: @escaping (HotkeyBinding?) -> Void) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
                 Text(label)
                     .font(.system(size: 13, weight: .medium))
                     .frame(width: 100, alignment: .leading)
-                KeyRecorderField(
-                    initialBinding: binding ?? HotkeyBinding(keyCode: 0, modifiersRaw: 0),
-                    onCapture: { onCapture($0) },
-                    accent: prefs.accent.color,
-                    placeholder: "Not set"
-                )
-                .frame(width: 180, height: 28)
-                if binding != nil {
-                    Button("Clear") { onCapture(nil) }
-                        .controlSize(.small)
+                VStack(alignment: .leading, spacing: 6) {
+                    hotkeyBindingRow(label: "Primary", binding: binding, onCapture: onCapture)
+                    hotkeyBindingRow(label: "Alternate", binding: alternate, onCapture: onAlternateCapture)
                 }
                 Spacer()
             }
@@ -743,6 +762,31 @@ struct SettingsView: View {
                     .padding(.leading, 112)
             }
         }
+    }
+
+    private func hotkeyBindingRow(label: String, binding: HotkeyBinding?, onCapture: @escaping (HotkeyBinding?) -> Void) -> some View {
+        HStack(spacing: 8) {
+            Text(label)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .frame(width: 54, alignment: .leading)
+            KeyRecorderField(
+                initialBinding: binding ?? HotkeyBinding(keyCode: 0, modifiersRaw: 0),
+                onCapture: { onCapture($0) },
+                accent: prefs.accent.color,
+                placeholder: "Not set"
+            )
+            .frame(width: 150, height: 28)
+            if binding != nil {
+                Button { onCapture(nil) } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Clear \(label.lowercased()) shortcut")
+            }
+        }
+        .frame(height: 28)
     }
 
     private func accentSwatch(_ choice: SwitchPreferences.AccentChoice) -> some View {
@@ -776,16 +820,7 @@ struct SettingsView: View {
         }
     }
 
-    private func apply(_ b: HotkeyBinding, save: (HotkeyBinding) -> Void) {
-        if let msg = HotkeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags) {
-            rejectMessage = msg
-        } else {
-            rejectMessage = nil
-            save(b)
-        }
-    }
-
-    private func applyHotkey(_ b: HotkeyBinding?, save: (HotkeyBinding?) -> Void) {
+    private func applyHotkey(_ b: HotkeyBinding?, replacing old: HotkeyBinding?, save: (HotkeyBinding?) -> Void) {
         guard let b else {
             rejectMessage = nil
             save(nil)
@@ -793,10 +828,19 @@ struct SettingsView: View {
         }
         if let msg = HotkeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags) {
             rejectMessage = msg
+        } else if configuredHotkeys.contains(where: { $0 != old && $0.conflicts(with: b) }) {
+            rejectMessage = "That shortcut is already assigned."
         } else {
             rejectMessage = nil
             save(b)
         }
+    }
+
+    private var configuredHotkeys: [HotkeyBinding] {
+        [model.allWindows, model.allWindowsAlternate,
+         model.currentApp, model.currentAppAlternate,
+         model.spaces, model.spacesAlternate,
+         model.stickyToggle].compactMap { $0 }
     }
 
 }

--- a/Sources/Switch/SwitchModel.swift
+++ b/Sources/Switch/SwitchModel.swift
@@ -21,6 +21,7 @@ final class SwitchModel: ObservableObject {
     private var armGeneration = 0
     private var armFrontmostPID: pid_t?
     private var armSelfHadKeyWindow = false
+    private var quitPIDs: Set<pid_t> = []
     private var thumbnailTasks: [Task<Void, Never>] = []
     var pointerWindowID: CGWindowID?
 
@@ -59,6 +60,7 @@ final class SwitchModel: ObservableObject {
         armGeneration &+= 1
         let gen = armGeneration
         self.mode = mode
+        quitPIDs.removeAll()
         filterText = ""
         pointerWindowID = nil
         armFrontmostPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
@@ -156,6 +158,8 @@ final class SwitchModel: ObservableObject {
     private func buildWindowList(from full: WindowEnumerator.FullSnapshot) -> [WindowInfo] {
         var active = full.activeSpace
         var cross = full.crossSpace
+        active.removeAll { quitPIDs.contains($0.pid) }
+        cross.removeAll { quitPIDs.contains($0.pid) }
         if mode == .currentApp, let f = armFrontmostPID {
             active = active.filter { $0.pid == f }
             cross = cross.filter { $0.pid == f }
@@ -344,8 +348,10 @@ final class SwitchModel: ObservableObject {
         guard mode != .spaces else { return }
         let list = filteredWindows
         guard list.indices.contains(selected) else { return }
-        AppCloser.close(list[selected])
-        cancelAndDismiss?()
+        let target = list[selected]
+        AppCloser.close(target)
+        quitPIDs.insert(target.pid)
+        removeFromPicker { $0.pid == target.pid }
     }
 
 


### PR DESCRIPTION
## Summary

- keep the picker open after quitting selected apps
- add one alternate shortcut for each switcher mode
- simplify the contribution guidelines

Closes #94

## Testing

- `xcodebuild -project Switch.xcodeproj -scheme Switch -configuration Debug -destination "platform=macOS" build`
- live-tested batch app quitting
- live-tested primary and alternate shortcuts, including modifier-release commit