### PR TITLE
Use AX titles when window names are missing

### DIFF
--- a/Sources/Switch/SwitchModel.swift
+++ b/Sources/Switch/SwitchModel.swift
@@ -208,8 +208,8 @@ final class SwitchModel: ObservableObject {
                         id: CGWindowID(0xF0000000) | CGWindowID(UInt32(bitPattern: Int32(app.processIdentifier))),
                         pid: app.processIdentifier,
                         appName: app.localizedName ?? "",
-                        title: "",
                         bounds: .zero,
+                        title: "",
                         isWindowless: true,
                         bundleID: app.bundleIdentifier
                     )

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -6,8 +6,8 @@ struct WindowInfo: Identifiable, Hashable {
     let id: CGWindowID
     let pid: pid_t
     let appName: String
-    let title: String
     let bounds: CGRect
+    var title: String
     var spaceID: Int?
     var isCrossSpace: Bool = false
     var isMinimized: Bool = false
@@ -129,15 +129,29 @@ enum WindowEnumerator {
             return out
         }
         let annotatedAll = annotateAndPrune(marked, ax: ax, cid: cid, metadata: metadata, stageManager: stageManager, titlesReliable: titlesReliable)
+        let titledActive = active.map { w -> WindowInfo in
+            var out = w
+            if out.title.isEmpty, let title = ax.titles[out.id], !title.isEmpty {
+                out.title = title
+            }
+            return out
+        }
+        let titledAll = annotatedAll.map { w -> WindowInfo in
+            var out = w
+            if out.title.isEmpty, let title = ax.titles[out.id], !title.isEmpty {
+                out.title = title
+            }
+            return out
+        }
         let onScreenIDs = Set(onScreen.map(\.id))
         housekeepGhostState(
             onScreen: onScreenIDs,
             enumerated: onScreenIDs.union(everything.map(\.id)),
             axBacked: ax.axBacked
         )
-        let cross = annotatedAll.filter { !activeIDs.contains($0.id) }
-        let reps = spaceRepresentatives(from: annotatedAll, cid: cid, metadata: metadata)
-        return FullSnapshot(activeSpace: active, crossSpace: cross, spaceRepresentatives: reps)
+        let cross = titledAll.filter { !activeIDs.contains($0.id) }
+        let reps = spaceRepresentatives(from: titledAll, cid: cid, metadata: metadata)
+        return FullSnapshot(activeSpace: titledActive, crossSpace: cross, spaceRepresentatives: reps)
     }
 
     static func currentWindows(scope: HotkeyManager.Mode, frontmostPID: pid_t?) -> [WindowInfo] {
@@ -170,10 +184,11 @@ enum WindowEnumerator {
         return el
     }
 
-    // AX-backed and minimized window IDs for the given processes; an orderedOut leftover appears in neither.
-    private static func axWindowState(for pids: Set<pid_t>) -> (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>) {
+    // AX-backed windows, minimized window IDs, and AX titles for the given processes; an orderedOut leftover appears in neither.
+    private static func axWindowState(for pids: Set<pid_t>) -> (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>, titles: [CGWindowID: String]) {
         var axBacked: Set<CGWindowID> = []
         var minimized: Set<CGWindowID> = []
+        var titles: [CGWindowID: String] = [:]
         for pid in pids {
             let appAX = appElement(for: pid)
             var ref: CFTypeRef?
@@ -184,6 +199,10 @@ enum WindowEnumerator {
                 if _AXUIElementGetWindow(ax, &id) == .success, id != 0 {
                     axBacked.insert(id)
                     AXWindowCache.store(ax, for: id)
+                    let title = AXHelpers.title(of: ax)
+                    if !title.isEmpty {
+                        titles[id] = title
+                    }
                     var minRef: CFTypeRef?
                     if AXUIElementCopyAttributeValue(ax, kAXMinimizedAttribute as CFString, &minRef) == .success,
                        let isMin = minRef as? Bool, isMin {
@@ -192,7 +211,7 @@ enum WindowEnumerator {
                 }
             }
         }
-        return (axBacked, minimized)
+        return (axBacked, minimized, titles)
     }
 
     // Drop orphaned on-screen entries: no live AX window and no Space. Real windows always have a Space.
@@ -208,7 +227,7 @@ enum WindowEnumerator {
 
     private static func annotateAndPrune(
         _ candidates: [WindowInfo],
-        ax: (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>),
+        ax: (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>, titles: [CGWindowID: String]),
         cid: CGSConnectionID,
         metadata: (labels: [Int: (label: String, isFullscreen: Bool)], order: [Int], currentSpaces: Set<Int>),
         stageManager: Bool,
@@ -286,8 +305,8 @@ enum WindowEnumerator {
                 id: target.id,
                 pid: target.pid,
                 appName: info?.label ?? "Desktop",
-                title: detail,
                 bounds: target.bounds,
+                title: detail,
                 spaceID: sid,
                 isCrossSpace: sid != active,
                 isMinimized: false,
@@ -375,8 +394,8 @@ enum WindowEnumerator {
                 id: id,
                 pid: pid,
                 appName: appName,
-                title: title,
                 bounds: bounds,
+                title: title,
                 isHidden: app?.isHidden == true,
                 bundleID: app?.bundleIdentifier
             ))


### PR DESCRIPTION
Fixes https://github.com/Sanyam-G/switch/issues/111

Not much experience with Swift apps - I'll be glad if you direct me in case something is wrong.

Tested on macOS v15.7.5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes windows showing no title in the switcher when the Accessibility title is available but the CoreGraphics window name is empty. It extends `axWindowState` to collect AX titles alongside the existing `axBacked`/`minimized` data, then applies a backfill map over `active` and `annotatedAll` before constructing the `FullSnapshot`.

- `WindowInfo.title` is changed from `let` to `var` to allow mutation in the two backfill map closures; ghost detection in `annotateAndPrune` is deliberately left unchanged, since AX-backed windows (the only ones that can supply an AX title) already bypass the empty-title ghost heuristic, keeping the fix safe.
- `SwitchModel.swift` has a cosmetic parameter reordering in the windowless-app `WindowInfo` initializer to match the updated struct field order.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the change is a targeted display-only backfill that does not touch ghost detection, space annotation, or window focus logic.
- The backfill only runs when `out.title.isEmpty` and an AX title is available, so it cannot overwrite a valid CG title. Ghost detection remains driven by the original CG title, and AX-backed windows already bypass that heuristic entirely, meaning the fix cannot cause windows to be incorrectly dropped or promoted.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Sources/Switch/WindowEnumerator.swift | Adds AX title collection in `axWindowState` and applies a backfill pass to `active`/`annotatedAll` before building the snapshot. Ghost-detection logic correctly remains unaffected because AX-backed windows (the only ones that can have AX titles) bypass the empty-title ghost heuristic. The `title` property on `WindowInfo` is changed from `let` to `var` to allow mutation in the map closures. |
| Sources/Switch/SwitchModel.swift | Cosmetic reordering of `title:` and `bounds:` in the windowless-app `WindowInfo` initializer to match the updated struct field order. No logic change. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant FS as fullSnapshot()
    participant AX as axWindowState()
    participant AP as annotateAndPrune()
    participant TB as AX Title Backfill

    FS->>AX: pids
    AX-->>FS: (axBacked, minimized, titles[CGWindowID→String])
    Note over AX: NEW: reads AXHelpers.title() per window

    FS->>AP: marked windows + ax tuple
    Note over AP: Ghost detection uses CG title only<br/>(AX-backed windows skip ghost logic)
    AP-->>FS: annotatedAll

    FS->>TB: "active.map { backfill from ax.titles }"
    TB-->>FS: titledActive (activeSpace)

    FS->>TB: "annotatedAll.map { backfill from ax.titles }"
    TB-->>FS: titledAll

    FS-->>FS: "cross = titledAll.filter(!activeIDs)"
    FS-->>FS: "reps = spaceRepresentatives(from: titledAll)"
    FS-->>FS: FullSnapshot(activeSpace: titledActive, crossSpace: cross, spaceRepresentatives: reps)
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Use AX titles when window names are miss..."](https://github.com/sanyam-g/switch/commit/7553c8645b80f71ee87738d1eedf32fd455319a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47782703)</sub>

<!-- /greptile_comment -->