### PR TITLE
Move app activation before AX raise in WindowFocuser

### DIFF
--- a/Sources/Switch/WindowFocuser.swift
+++ b/Sources/Switch/WindowFocuser.swift
@@ -40,6 +40,12 @@ enum WindowFocuser {
         let app = NSRunningApplication(processIdentifier: window.pid)
         if app?.isHidden == true { app?.unhide() }
 
+        // When Switch itself is the active app (owns a key Settings/About window while
+        // staying .accessory), macOS 26 cooperative activation can ignore an activate()
+        // from the active app; yield first so the target actually comes forward.
+        if let app, NSApp.isActive { NSApp.yieldActivation(to: app) }
+        app?.activate(options: [])
+
         let appAX = AXUIElementCreateApplication(window.pid)
         var ref: CFTypeRef?
         let axWindows = (AXUIElementCopyAttributeValue(appAX, kAXWindowsAttribute as CFString, &ref) == .success
@@ -57,12 +63,6 @@ enum WindowFocuser {
         if !raised && window.isCrossSpace {
             focusViaWindowMenu(window)
         }
-
-        // When Switch itself is the active app (owns a key Settings/About window while
-        // staying .accessory), macOS 26 cooperative activation can ignore an activate()
-        // from the active app; yield first so the target actually comes forward.
-        if let app, NSApp.isActive { NSApp.yieldActivation(to: app) }
-        app?.activate(options: [])
 
         WindowMRU.touch(window.id)
     }


### PR DESCRIPTION
Moved app?.activate(options: []) before the AX operations in WindowFocuser.focus(). Previously it was called after AX window enumeration and raise, which meant apps with slow/non-standard AX implementations (like Godot) would block the activation behind those calls.

Closes #117

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves `app?.activate(options: [])` (and the `yieldActivation` guard) from after the Accessibility API window enumeration and raise to before them, so that apps with slow or non-standard AX implementations (e.g. Godot) are activated immediately rather than waiting for potentially blocking AX calls to complete.

- `yieldActivation(to: app)` and `activate(options: [])` are now the first substantive operations after `unhide()`, ensuring the app comes to the foreground regardless of AX responsiveness.
- The existing `kAXFocusedWindowAttribute` write and `kAXRaiseAction` are unchanged in position, but the comment stating that the focused-window hint \"steers which Space `activate()` lands on\" is now inaccurate — `activate()` has already been dispatched by the time that attribute is set. For cross-Space non-Chromium apps the `kAXRaiseAction` should still deliver the correct window, but a redundant Space switch could be observable.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the common case; the Godot/slow-AX fix is straightforward and correct, but the multi-Space switching scenario deserves a manual smoke-test before landing.

The reordering is well-motivated and the fix for non-standard AX apps is sound. The only concern is the kAXFocusedWindowAttribute hint that was meant to steer Space selection in activate() — it now runs after activate() has already been dispatched, so its Space-steering effect is lost. For cross-Space Chromium windows the focusViaWindowMenu fallback covers failures, but for other apps with windows on multiple Spaces there could be a brief extra Space jump. The cross-Space comment in the code is also now misleading and should be updated.

**Files Needing Attention:** Sources/Switch/WindowFocuser.swift — specifically the multi-Space activation path and the now-stale kAXFocusedWindowAttribute comment at line 57.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Sources/Switch/WindowFocuser.swift | Moved app activation (yieldActivation + activate) before AX window enumeration and raise to fix apps with slow AX implementations (Godot). The kAXFocusedWindowAttribute hint that previously steered which Space activate() landed on now runs after activate(), making the comment misleading and potentially causing an extra Space transition for multi-Space window scenarios. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Caller
    participant WF as WindowFocuser.focus()
    participant OS as macOS / NSApp
    participant AX as Accessibility API

    C->>WF: focus(window)
    WF->>WF: unhide() if hidden

    Note over WF,OS: NEW order (after this PR)
    WF->>OS: yieldActivation(to: app) [if Switch is active]
    WF->>OS: app.activate(options: [])

    WF->>AX: AXUIElementCopyAttributeValue (kAXWindowsAttribute)
    AX-->>WF: axWindows []

    WF->>WF: bestMatch(for: window, in: axWindows)
    WF->>AX: AXUIElementSetAttributeValue(kAXMainAttribute)
    WF->>AX: AXUIElementSetAttributeValue(kAXFocusedWindowAttribute)
    WF->>AX: AXUIElementPerformAction(kAXRaiseAction)
    AX-->>WF: raised: Bool

    alt raise failed AND cross-space
        WF->>WF: focusViaWindowMenu(window)
    end

    WF->>WF: WindowMRU.touch(window.id)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/Switch/WindowFocuser.swift`, line 56-59 ([link](https://github.com/sanyam-g/switch/blob/827fc2467aa6cacb20c066d307d9c4ba7a398415/Sources/Switch/WindowFocuser.swift#L56-L59)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`kAXFocusedWindowAttribute` hint now runs after `activate()`**

   The comment on line 57 says "Focused-window steers which Space `activate()` lands on" — but `activate()` is now called ~10 lines earlier, so this `kAXFocusedWindowAttribute` write no longer influences where macOS delivers that activation. For normal same-Space windows this is harmless (the subsequent `kAXRaiseAction` still raises the correct window), but for apps with windows spread across multiple Spaces, macOS may snap the view to whichever Space the app last held, and then `kAXRaiseAction` must trigger a second Space transition. The comment should be updated to reflect the new semantics, and it's worth manually verifying the multi-Space scenario (e.g. Chrome with one window on Space 1 and another on Space 2) still switches to the correct Space without an extra visible jump.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Update WindowFocuser.swift"](https://github.com/sanyam-g/switch/commit/827fc2467aa6cacb20c066d307d9c4ba7a398415) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47782701)</sub>

<!-- /greptile_comment -->