### PR TITLE
esc combos and faster same-space activation

### DIFF
--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -1072,11 +1072,13 @@ final class KeyRecorderNSView: NSView {
         if type == .flagsChanged { return nil }
         guard type == .keyDown else { return Unmanaged.passUnretained(event) }
         let kc = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
+        let mods: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
+        let held = event.flags.intersection(mods)
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            if kc != 53 {
-                let mods: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
-                let b = HotkeyBinding(keyCode: UInt16(kc), modifiersRaw: event.flags.intersection(mods).rawValue)
+            // Bare Esc cancels; Esc with a modifier is a recordable combo (#116).
+            if kc != 53 || !held.isEmpty {
+                let b = HotkeyBinding(keyCode: UInt16(kc), modifiersRaw: held.rawValue)
                 self.binding = b
                 self.onCapture?(b)
             }

--- a/Sources/Switch/WindowFocuser.swift
+++ b/Sources/Switch/WindowFocuser.swift
@@ -40,6 +40,16 @@ enum WindowFocuser {
         let app = NSRunningApplication(processIdentifier: window.pid)
         if app?.isHidden == true { app?.unhide() }
 
+        // Same-Space targets activate immediately so slow AX apps (Godot, #117)
+        // come forward without waiting on the raise calls below. Cross-Space keeps
+        // activation last: the focused-window write must steer it first.
+        // ponytail: if the app's internal focus sits on another Space this can flash
+        // that Space before the raise corrects it; per-window Space check if reported.
+        if !window.isCrossSpace {
+            if let app, NSApp.isActive { NSApp.yieldActivation(to: app) }
+            app?.activate(options: [])
+        }
+
         let appAX = AXUIElementCreateApplication(window.pid)
         var ref: CFTypeRef?
         let axWindows = (AXUIElementCopyAttributeValue(appAX, kAXWindowsAttribute as CFString, &ref) == .success
@@ -61,8 +71,10 @@ enum WindowFocuser {
         // When Switch itself is the active app (owns a key Settings/About window while
         // staying .accessory), macOS 26 cooperative activation can ignore an activate()
         // from the active app; yield first so the target actually comes forward.
-        if let app, NSApp.isActive { NSApp.yieldActivation(to: app) }
-        app?.activate(options: [])
+        if window.isCrossSpace {
+            if let app, NSApp.isActive { NSApp.yieldActivation(to: app) }
+            app?.activate(options: [])
+        }
 
         WindowMRU.touch(window.id)
     }

--- a/Sources/Switch/WindowFocuser.swift
+++ b/Sources/Switch/WindowFocuser.swift
@@ -40,11 +40,10 @@ enum WindowFocuser {
         let app = NSRunningApplication(processIdentifier: window.pid)
         if app?.isHidden == true { app?.unhide() }
 
-        // Same-Space targets activate immediately so slow AX apps (Godot, #117)
-        // come forward without waiting on the raise calls below. Cross-Space keeps
-        // activation last: the focused-window write must steer it first.
-        // ponytail: if the app's internal focus sits on another Space this can flash
-        // that Space before the raise corrects it; per-window Space check if reported.
+        // Same-Space targets get an early best-effort activate so slow AX apps
+        // (Godot, #117) start coming forward before the raise calls below. The
+        // late activate still runs; cross-Space skips this because the
+        // focused-window write must steer activation first.
         if !window.isCrossSpace {
             if let app, NSApp.isActive { NSApp.yieldActivation(to: app) }
             app?.activate(options: [])
@@ -71,10 +70,8 @@ enum WindowFocuser {
         // When Switch itself is the active app (owns a key Settings/About window while
         // staying .accessory), macOS 26 cooperative activation can ignore an activate()
         // from the active app; yield first so the target actually comes forward.
-        if window.isCrossSpace {
-            if let app, NSApp.isActive { NSApp.yieldActivation(to: app) }
-            app?.activate(options: [])
-        }
+        if let app, NSApp.isActive { NSApp.yieldActivation(to: app) }
+        app?.activate(options: [])
 
         WindowMRU.touch(window.id)
     }


### PR DESCRIPTION
Two fixes:

- #116: the shortcut recorder cancelled on Esc before checking modifiers, so combos like ⌘⎋ could never be recorded. Esc with a modifier held now records, bare Esc still cancels.
- #117: apps with slow accessibility implementations (Godot) took a beat to come forward because activation waited on the AX raise calls. Same-Space targets now get an early activate before the AX work; cross-Space keeps the existing order since the focused-window write steers which Space activation lands on. The late activate stays as a fallback in both cases.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR contains two targeted bug fixes: it allows Esc+modifier key combos (e.g. ⌘⎋) to be recorded in the hotkey recorder by moving modifier-flag capture to before the async dispatch and widening the record predicate, and it adds an early `activate()` call for same-Space targets in `WindowFocuser` so that apps with slow accessibility implementations (e.g. Godot) begin coming forward before the AX raise calls execute.

- **SettingsView.swift**: `held` is now computed synchronously in the event tap callback rather than inside the `DispatchQueue.main.async` closure, ensuring the modifier state snapshot is taken at event time. The condition `kc != 53 || !held.isEmpty` correctly preserves bare-Esc cancellation while unblocking modifier+Esc combos.
- **WindowFocuser.swift**: Same-Space targets receive an early `yieldActivation`+`activate()` before the AX window-raise block; cross-Space windows correctly skip this path since the `kAXFocusedWindowAttribute` write must precede activation to steer which Space the OS lands on. The existing late activate at the bottom remains as a fallback for both paths.

<h3>Confidence Score: 4/5</h3>

Both changes are narrow and well-scoped; the recorder fix is straightforward and the early-activate path in WindowFocuser is guarded correctly by the isCrossSpace check.

The SettingsView change is simple and correct. The WindowFocuser change introduces a second activate() call for same-Space windows — the double-activate sequence (early then late fallback) is intentional, but it adds a new code path through the cooperative-activation (yieldActivation) logic that was only exercised by the late activate before. This is a best-effort macOS heuristic and any unexpected interaction would manifest as a cosmetic focus glitch rather than data loss, but it merits a quick smoke-test against a cross-app scenario on macOS 14+ before shipping.

**Files Needing Attention:** WindowFocuser.swift — specifically the same-Space early-activate block and its interaction with the existing late activate at the bottom of focus().

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Sources/Switch/SettingsView.swift | Moves modifier-flag computation before the async dispatch so `held` is captured synchronously from the event, then widens the record condition from `kc != 53` to `kc != 53 || !held.isEmpty` — correctly allowing Esc+modifier combos while preserving bare-Esc cancellation. |
| Sources/Switch/WindowFocuser.swift | Adds an early best-effort activate (with yieldActivation guard) for same-space targets before the AX raise block so slow-AX apps start coming forward sooner; cross-space targets correctly skip this to let the focused-window write steer which Space the activation lands on. The late activate at the bottom remains as a fallback for both paths. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ET as Event Tap
    participant MQ as Main Queue
    participant AX as Accessibility API
    participant App as Target App

    Note over ET,MQ: SettingsView key recorder fix (#116)
    ET->>ET: keyDown received
    ET->>ET: "held = event.flags intersection modifiers"
    ET->>MQ: async dispatch with kc and held
    MQ->>MQ: "kc==53 and held empty → stopRecording only"
    MQ->>MQ: "kc==53 and held nonempty → record Esc combo + stopRecording"
    MQ->>MQ: "kc!=53 → record binding + stopRecording"

    Note over ET,App: WindowFocuser same-Space early activate (#117)
    ET->>App: focus(window) called
    alt Same-Space window
        App->>App: yieldActivation if NSApp.isActive
        App->>App: app.activate early
    end
    App->>AX: kAXWindowsAttribute
    AX-->>App: axWindows list
    App->>AX: kAXMainAttribute + kAXFocusedWindowAttribute + kAXRaiseAction
    App->>App: yieldActivation if NSApp.isActive
    App->>App: app.activate late fallback
```
</details>

<sub>Reviews (1): Last reviewed commit: ["keep late activate as fallback for same-..."](https://github.com/sanyam-g/switch/commit/0fbda83b45d3ac051ab98c4adb511475d833c8df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49395452)</sub>

<!-- /greptile_comment -->