### PR TITLE
Drop em dashes from comments and onboarding text

### DIFF
--- a/Sources/Switch/DebugFocusHarness.swift
+++ b/Sources/Switch/DebugFocusHarness.swift
@@ -85,7 +85,7 @@ final class DebugFocusHarness {
     }
 
     /// AX elements captured while their windows were on the active Space.
-    /// Remote AX handles stay valid after the window leaves the Space — this is
+    /// Remote AX handles stay valid after the window leaves the Space; this is
     /// how AltTab can raise windows Chromium no longer enumerates.
     nonisolated(unsafe) static var stash: [CGWindowID: AXUIElement] = [:]
 

--- a/Sources/Switch/FocusTracker.swift
+++ b/Sources/Switch/FocusTracker.swift
@@ -4,7 +4,7 @@ import ApplicationServices
 /// Watches AX focused-window changes across every running app so WindowMRU
 /// reflects all focus events, not just the ones Switch initiated. Without
 /// this, MRU only knows about Switch-driven focus, and active-Space ordering
-/// falls back to CGWindowList z-order — which clusters all of an app's
+/// falls back to CGWindowList z-order, which clusters all of an app's
 /// windows together when any one of them is raised.
 /// All methods run on the main thread; not @MainActor-annotated so AppDelegate
 /// can call start() from synchronous lifecycle hooks.
@@ -61,7 +61,7 @@ final class FocusTracker {
         CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .defaultMode)
     }
 
-    /// Touch MRU on app activation as a backstop — AX observers don't always
+    /// Touch MRU on app activation as a backstop; AX observers don't always
     /// fire reliably immediately after an app launches, but didActivate does.
     private func touchFocused(of pid: pid_t) {
         let appAX = AXUIElementCreateApplication(pid)

--- a/Sources/Switch/OnboardingView.swift
+++ b/Sources/Switch/OnboardingView.swift
@@ -38,7 +38,7 @@ struct OnboardingView: View {
 
             HStack {
                 if model.allGranted {
-                    Label("Ready — hold ⌘-Tab to switch windows.",
+                    Label("Ready. Hold ⌘-Tab to switch windows.",
                           systemImage: "checkmark.circle.fill")
                         .foregroundStyle(.green)
                         .font(.system(size: 12, weight: .medium))

--- a/Sources/Switch/SwitchModel.swift
+++ b/Sources/Switch/SwitchModel.swift
@@ -139,7 +139,7 @@ final class SwitchModel: ObservableObject {
             let liveIDs = Set(thumbTargets.map { $0.id })
             let task = Task {
                 if SwitchPreferences.shared.showThumbnails, #available(macOS 14.0, *) {
-                    // Don't full-purge — pre-warmed thumbs are valid as long as the window still exists.
+                    // Don't full-purge; pre-warmed thumbs are valid as long as the window still exists.
                     await WindowSnapshotter.shared.purge(keeping: liveIDs)
                 }
                 await fetchThumbnails(for: thumbTargets, force: false)

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -193,7 +193,7 @@ struct SwitchView: View {
                         }
                     }
                     .onChange(of: model.selected) { _, new in
-                        // Skip auto-scroll when selection came from mouse hover —
+                        // Skip auto-scroll when selection came from mouse hover;
                         // user is already looking at where they're pointing.
                         if lastSelectionFromMouse {
                             lastSelectionFromMouse = false

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -248,7 +248,7 @@ enum WindowEnumerator {
                 // so a real window caught mid Space-transition survives (transitions
                 // settle in <1s; Current Space races ahead of CGWindowList and Chromium
                 // exposes no AX in that gap): claims the current Space, or has an empty
-                // CG title — real cross-Space windows always carry one (browser windows
+                // CG title; real cross-Space windows always carry one (browser windows
                 // have a page title), so an untitled shell on any live Space is a ghost.
                 let currentClaim = spaces.contains(where: { metadata.currentSpaces.contains($0) })
                 if out.isCrossSpace && (currentClaim || (titlesReliable && out.title.isEmpty)) {
@@ -366,7 +366,7 @@ enum WindowEnumerator {
             if bounds.width < 100 || bounds.height < 80 { continue }
             if title.isEmpty && titlesReliable
                 && (bounds.width < 400 || bounds.height < 300) { continue }
-            // Dedupe by CGWindowID only — it's already unique per window.
+            // Dedupe by CGWindowID only; it's already unique per window.
             // The earlier (pid, title, bounds) dedupe was collapsing multiple
             // Chrome windows that shared the same active-tab title.
             if seenIDs.contains(id) { continue }

--- a/Sources/Switch/WindowFocuser.swift
+++ b/Sources/Switch/WindowFocuser.swift
@@ -128,7 +128,7 @@ enum WindowFocuser {
     /// element captured while the window was on-screen (Chromium apps hide
     /// off-Space windows from kAXWindowsAttribute entirely, so the live list
     /// misses exactly the windows that need cross-Space focusing). Bounds and
-    /// title matching remain as last resorts; never `first` — raising an
+    /// title matching remain as last resorts; never `first`; raising an
     /// arbitrary sibling sends focus to the wrong window.
     private static func bestMatch(for window: WindowInfo, in axWindows: [AXUIElement]) -> AXUIElement? {
         if let exact = axWindows.first(where: { axWindowID($0) == window.id }) {
@@ -163,7 +163,7 @@ enum WindowCloser {
     static func close(_ window: WindowInfo) { pressButton(window, attribute: kAXCloseButtonAttribute) }
 
     /// Close only the specific window, resolving its AX element the way focus does
-    /// (live wid match, then AXWindowCache) — never an arbitrary sibling. Returns
+    /// (live wid match, then AXWindowCache), never an arbitrary sibling. Returns
     /// false without acting when nothing resolves, so callers can decline to fall back.
     @discardableResult
     static func closeExact(_ window: WindowInfo) -> Bool {


### PR DESCRIPTION
Comment and string cleanup, no behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a pure cosmetic cleanup replacing em dashes (`—`) with semicolons (or a period) in comments across six Swift files, plus one user-visible string change in the onboarding flow. No runtime behavior is affected anywhere except for the rephrased onboarding label.

- **Comments (6 files):** Every em dash used as a clause connector in doc and inline comments is replaced with a semicolon, making the punctuation more conventional for ASCII-safe tooling and consistent across the codebase.
- **Onboarding string (`OnboardingView.swift`):** \"Ready — hold ⌘-Tab to switch windows.\" becomes \"Ready. Hold ⌘-Tab to switch windows.\" — the em dash is replaced with a full stop, splitting the sentence in two.

<h3>Confidence Score: 5/5</h3>

All changes are comment text and one user-facing label; no executable logic is touched.

Every diff hunk is either a comment line or a single string literal in the onboarding UI. No control flow, data structures, or API calls are modified, so there is no realistic path to a regression.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Sources/Switch/OnboardingView.swift | User-visible label text changed from 'Ready — hold ⌘-Tab to switch windows.' to 'Ready. Hold ⌘-Tab to switch windows.' — em dash replaced with a period, splitting the sentence. |
| Sources/Switch/FocusTracker.swift | Two em dashes in doc comments replaced with semicolons; no logic change. |
| Sources/Switch/WindowEnumerator.swift | Two em dashes in inline comments replaced with semicolons; no logic change. |
| Sources/Switch/WindowFocuser.swift | Two em dashes in doc comments replaced with semicolons; no logic change. |
| Sources/Switch/DebugFocusHarness.swift | Single em dash in a doc comment replaced with a semicolon; no logic change. |
| Sources/Switch/SwitchModel.swift | Single em dash in an inline comment replaced with a semicolon; no logic change. |
| Sources/Switch/SwitchView.swift | Single em dash in an inline comment replaced with a semicolon; no logic change. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: Drop em dashes] --> B{Change type}
    B --> C[Comments only\nDebugFocusHarness, FocusTracker,\nSwitchModel, SwitchView,\nWindowEnumerator, WindowFocuser]
    B --> D[User-visible string\nOnboardingView]
    C --> E["em dash → semicolon\nin doc/inline comments"]
    D --> F["'Ready — hold ⌘-Tab…'\n→ 'Ready. Hold ⌘-Tab…'"]
    E --> G[No runtime effect]
    F --> H[Onboarding label updated]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["drop em dashes from comments and onboard..."](https://github.com/sanyam-g/switch/commit/40c5b2f040f98be28d5c81421d16c79fe7ebc534) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49987305)</sub>

<!-- /greptile_comment -->