### PR TITLE
Fix update toggle persistence, hidden-app duplicates, cross-Space filter, selection animation

### DIFF
--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -10,7 +10,7 @@ extension Notification.Name {
 }
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    // NSApp.delegate is SwiftUI's internal delegate under the adaptor; a cast never finds this instance (#127).
+    // Under the SwiftUI lifecycle NSApp.delegate is SwiftUI's own wrapper, so casting it to AppDelegate finds nothing (#127).
     private(set) static weak var shared: AppDelegate?
 
     override init() {

--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -10,6 +10,14 @@ extension Notification.Name {
 }
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    // NSApp.delegate is SwiftUI's internal delegate under the adaptor; a cast never finds this instance (#127).
+    private(set) static weak var shared: AppDelegate?
+
+    override init() {
+        super.init()
+        AppDelegate.shared = self
+    }
+
     #if canImport(Sparkle)
     private lazy var updaterController = SPUStandardUpdaterController(
         startingUpdater: true,

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -21,7 +21,7 @@ final class SettingsModel: ObservableObject {
     init() { refresh() }
 
     #if canImport(Sparkle)
-    private var updater: SPUUpdater? { (NSApp.delegate as? AppDelegate)?.sparkleUpdater }
+    private var updater: SPUUpdater? { AppDelegate.shared?.sparkleUpdater }
     #endif
 
     func refresh() {

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -506,7 +506,7 @@ private struct SelectionChrome: ViewModifier {
     func body(content: Content) -> some View {
         content
             .background(
-                // Rounded fills, not clipShape: the row's static clip hid the matched-geometry fill mid-flight (#133).
+                // A row-level clip would hide the matched-geometry fill while it travels between rows (#133).
                 ZStack {
                     if hovered && !selected {
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -506,7 +506,7 @@ private struct SelectionChrome: ViewModifier {
     func body(content: Content) -> some View {
         content
             .background(
-                // A row-level clip would hide the matched-geometry fill while it travels between rows (#133).
+                // Clipping at the row level hides the matched-geometry fill while it slides between rows, so the rounding lives on the fills themselves (#133).
                 ZStack {
                     if hovered && !selected {
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -506,17 +506,19 @@ private struct SelectionChrome: ViewModifier {
     func body(content: Content) -> some View {
         content
             .background(
+                // Rounded fills, not clipShape: the row's static clip hid the matched-geometry fill mid-flight (#133).
                 ZStack {
                     if hovered && !selected {
-                        Color.white.opacity(0.06)
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .fill(Color.white.opacity(0.06))
                     }
                     if selected {
-                        accent.opacity(0.22)
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .fill(accent.opacity(0.22))
                             .matchedGeometryEffect(id: "selectionBG", in: namespace)
                     }
                 }
             )
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             .overlay(
                 ZStack {
                     if selected {

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -180,7 +180,7 @@ enum WindowEnumerator {
             var ref: CFTypeRef?
             guard AXUIElementCopyAttributeValue(appAX, kAXWindowsAttribute as CFString, &ref) == .success,
                   let axWindows = ref as? [AXUIElement] else { continue }
-            responsive.insert(pid)
+            var allMapped = true
             for ax in axWindows {
                 var id: CGWindowID = 0
                 if _AXUIElementGetWindow(ax, &id) == .success, id != 0 {
@@ -191,8 +191,12 @@ enum WindowEnumerator {
                        let isMin = minRef as? Bool, isMin {
                         minimized.insert(id)
                     }
+                } else {
+                    allMapped = false
                 }
             }
+            // An unmapped AX window could be any of the pid's unbacked CG windows, so a partial answer proves nothing against them.
+            if allMapped { responsive.insert(pid) }
         }
         return (axBacked, minimized, responsive)
     }

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -221,18 +221,20 @@ enum WindowEnumerator {
             let arr = [NSNumber(value: w.id)] as CFArray
             let spaces = CGSCopySpacesForWindows(cid, 7, arr)?.takeRetainedValue() as? [Int] ?? []
             if out.isHidden || ax.minimized.contains(w.id) {
+                out.isMinimized = ax.minimized.contains(w.id)
+                // A window with no Space claim counts as current, older macOS drops the assignment once a window is ordered out (#129).
+                out.isCrossSpace = !spaces.isEmpty && !spaces.contains(where: { metadata.currentSpaces.contains($0) })
                 // Hidden Electron apps keep AX-less shell windows; only an app that answered AX and still doesn't list the window marks a shell, a timed-out query is no evidence (#126).
                 if ax.responsive.contains(w.pid) {
                     let backed = ax.axBacked.contains(w.id) || AXWindowCache.element(for: w.id) != nil
-                    if backed {
+                    // Same real-window signature as the cross-Space prune below: uncached hidden Chromium windows on another Space answer to neither AX nor the cache.
+                    let offSpaceReal = out.isCrossSpace && (!titlesReliable || !w.title.isEmpty)
+                    if backed || offSpaceReal {
                         clearGhostStrike(w.id)
                     } else if ghostStrikeConfirmed(w.id) {
                         return nil
                     }
                 }
-                out.isMinimized = ax.minimized.contains(w.id)
-                // A window with no Space claim counts as current, older macOS drops the assignment once a window is ordered out (#129).
-                out.isCrossSpace = !spaces.isEmpty && !spaces.contains(where: { metadata.currentSpaces.contains($0) })
                 if let sid = spaces.first {
                     let info = metadata.labels[sid]
                     out.spaceID = sid

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -216,17 +216,22 @@ enum WindowEnumerator {
     ) -> [WindowInfo] {
         return candidates.compactMap { w in
             var out = w
-            if out.isHidden {
-                out.isCrossSpace = false
-                return out
-            }
-            if ax.minimized.contains(w.id) {
-                out.isMinimized = true
-                out.isCrossSpace = false
-                return out
-            }
             let arr = [NSNumber(value: w.id)] as CFArray
             let spaces = CGSCopySpacesForWindows(cid, 7, arr)?.takeRetainedValue() as? [Int] ?? []
+            if out.isHidden || ax.minimized.contains(w.id) {
+                // Real hidden/minimized windows are AX-backed; hidden Electron shells aren't and showed as duplicates (#126).
+                guard ax.axBacked.contains(w.id) else { return nil }
+                out.isMinimized = ax.minimized.contains(w.id)
+                // Keep the Space claim so the cross-Space toggle applies (#129); no claim counts as current.
+                out.isCrossSpace = !spaces.isEmpty && !spaces.contains(where: { metadata.currentSpaces.contains($0) })
+                if let sid = spaces.first {
+                    let info = metadata.labels[sid]
+                    out.spaceID = sid
+                    out.spaceLabel = info?.label
+                    out.isFullscreenSpace = info?.isFullscreen ?? false
+                }
+                return out
+            }
             if spaces.isEmpty {
                 // Empty Space list + no AX window = orderOut'd ghost, drop it.
                 // Empty Space list + live AX window = a real window the window

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -171,14 +171,16 @@ enum WindowEnumerator {
     }
 
     // AX-backed and minimized window IDs for the given processes; an orderedOut leftover appears in neither.
-    private static func axWindowState(for pids: Set<pid_t>) -> (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>) {
+    private static func axWindowState(for pids: Set<pid_t>) -> (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>, responsive: Set<pid_t>) {
         var axBacked: Set<CGWindowID> = []
         var minimized: Set<CGWindowID> = []
+        var responsive: Set<pid_t> = []
         for pid in pids {
             let appAX = appElement(for: pid)
             var ref: CFTypeRef?
             guard AXUIElementCopyAttributeValue(appAX, kAXWindowsAttribute as CFString, &ref) == .success,
                   let axWindows = ref as? [AXUIElement] else { continue }
+            responsive.insert(pid)
             for ax in axWindows {
                 var id: CGWindowID = 0
                 if _AXUIElementGetWindow(ax, &id) == .success, id != 0 {
@@ -192,7 +194,7 @@ enum WindowEnumerator {
                 }
             }
         }
-        return (axBacked, minimized)
+        return (axBacked, minimized, responsive)
     }
 
     // Drop orphaned on-screen entries: no live AX window and no Space. Real windows always have a Space.
@@ -208,7 +210,7 @@ enum WindowEnumerator {
 
     private static func annotateAndPrune(
         _ candidates: [WindowInfo],
-        ax: (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>),
+        ax: (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>, responsive: Set<pid_t>),
         cid: CGSConnectionID,
         metadata: (labels: [Int: (label: String, isFullscreen: Bool)], order: [Int], currentSpaces: Set<Int>),
         stageManager: Bool,
@@ -219,11 +221,14 @@ enum WindowEnumerator {
             let arr = [NSNumber(value: w.id)] as CFArray
             let spaces = CGSCopySpacesForWindows(cid, 7, arr)?.takeRetainedValue() as? [Int] ?? []
             if out.isHidden || ax.minimized.contains(w.id) {
-                // Hidden Electron apps keep shell windows with no AX backing; two strikes before dropping so one slow AX sweep doesn't eat real windows (#126).
-                if !ax.axBacked.contains(w.id) {
-                    if ghostStrikeConfirmed(w.id) { return nil }
-                } else {
-                    clearGhostStrike(w.id)
+                // Hidden Electron apps keep AX-less shell windows; only an app that answered AX and still doesn't list the window marks a shell, a timed-out query is no evidence (#126).
+                if ax.responsive.contains(w.pid) {
+                    let backed = ax.axBacked.contains(w.id) || AXWindowCache.element(for: w.id) != nil
+                    if backed {
+                        clearGhostStrike(w.id)
+                    } else if ghostStrikeConfirmed(w.id) {
+                        return nil
+                    }
                 }
                 out.isMinimized = ax.minimized.contains(w.id)
                 // A window with no Space claim counts as current, older macOS drops the assignment once a window is ordered out (#129).

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -219,10 +219,14 @@ enum WindowEnumerator {
             let arr = [NSNumber(value: w.id)] as CFArray
             let spaces = CGSCopySpacesForWindows(cid, 7, arr)?.takeRetainedValue() as? [Int] ?? []
             if out.isHidden || ax.minimized.contains(w.id) {
-                // Real hidden/minimized windows are AX-backed; hidden Electron shells aren't and showed as duplicates (#126).
-                guard ax.axBacked.contains(w.id) else { return nil }
+                // AX-less hidden shells (Electron) drop after two strikes; a single AX timeout spares real windows (#126).
+                if !ax.axBacked.contains(w.id) {
+                    if ghostStrikeConfirmed(w.id) { return nil }
+                } else {
+                    clearGhostStrike(w.id)
+                }
                 out.isMinimized = ax.minimized.contains(w.id)
-                // Keep the Space claim so the cross-Space toggle applies (#129); no claim counts as current.
+                // No Space claim counts as current, older macOS drops assignments on orderOut (#129).
                 out.isCrossSpace = !spaces.isEmpty && !spaces.contains(where: { metadata.currentSpaces.contains($0) })
                 if let sid = spaces.first {
                     let info = metadata.labels[sid]

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -171,16 +171,14 @@ enum WindowEnumerator {
     }
 
     // AX-backed and minimized window IDs for the given processes; an orderedOut leftover appears in neither.
-    private static func axWindowState(for pids: Set<pid_t>) -> (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>, responsive: Set<pid_t>) {
+    private static func axWindowState(for pids: Set<pid_t>) -> (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>) {
         var axBacked: Set<CGWindowID> = []
         var minimized: Set<CGWindowID> = []
-        var responsive: Set<pid_t> = []
         for pid in pids {
             let appAX = appElement(for: pid)
             var ref: CFTypeRef?
             guard AXUIElementCopyAttributeValue(appAX, kAXWindowsAttribute as CFString, &ref) == .success,
                   let axWindows = ref as? [AXUIElement] else { continue }
-            var allMapped = true
             for ax in axWindows {
                 var id: CGWindowID = 0
                 if _AXUIElementGetWindow(ax, &id) == .success, id != 0 {
@@ -191,14 +189,10 @@ enum WindowEnumerator {
                        let isMin = minRef as? Bool, isMin {
                         minimized.insert(id)
                     }
-                } else {
-                    allMapped = false
                 }
             }
-            // An unmapped AX window could be any of the pid's unbacked CG windows, so a partial answer proves nothing against them.
-            if allMapped { responsive.insert(pid) }
         }
-        return (axBacked, minimized, responsive)
+        return (axBacked, minimized)
     }
 
     // Drop orphaned on-screen entries: no live AX window and no Space. Real windows always have a Space.
@@ -214,7 +208,7 @@ enum WindowEnumerator {
 
     private static func annotateAndPrune(
         _ candidates: [WindowInfo],
-        ax: (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>, responsive: Set<pid_t>),
+        ax: (axBacked: Set<CGWindowID>, minimized: Set<CGWindowID>),
         cid: CGSConnectionID,
         metadata: (labels: [Int: (label: String, isFullscreen: Bool)], order: [Int], currentSpaces: Set<Int>),
         stageManager: Bool,
@@ -228,17 +222,11 @@ enum WindowEnumerator {
                 out.isMinimized = ax.minimized.contains(w.id)
                 // A window with no Space claim counts as current, older macOS drops the assignment once a window is ordered out (#129).
                 out.isCrossSpace = !spaces.isEmpty && !spaces.contains(where: { metadata.currentSpaces.contains($0) })
-                // Hidden Electron apps keep AX-less shell windows; only an app that answered AX and still doesn't list the window marks a shell, a timed-out query is no evidence (#126).
-                if ax.responsive.contains(w.pid) {
-                    let backed = ax.axBacked.contains(w.id) || AXWindowCache.element(for: w.id) != nil
-                    // Same real-window signature as the cross-Space prune below: uncached hidden Chromium windows on another Space answer to neither AX nor the cache.
-                    let offSpaceReal = out.isCrossSpace && (!titlesReliable || !w.title.isEmpty)
-                    if backed || offSpaceReal {
-                        clearGhostStrike(w.id)
-                    } else if ghostStrikeConfirmed(w.id) {
-                        return nil
-                    }
-                }
+                // A window AX ever backed is real; the cache outlives per-sweep AX gaps (timeouts, Chromium's off-Space omissions), so a never-backed CG entry is an Electron shell (#126).
+                let everBacked = ax.axBacked.contains(w.id) || AXWindowCache.element(for: w.id) != nil
+                // Same real-window signature as the cross-Space prune below, for windows hidden before Switch ever saw them.
+                let offSpaceReal = out.isCrossSpace && (!titlesReliable || !w.title.isEmpty)
+                guard everBacked || offSpaceReal else { return nil }
                 if let sid = spaces.first {
                     let info = metadata.labels[sid]
                     out.spaceID = sid

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -219,14 +219,14 @@ enum WindowEnumerator {
             let arr = [NSNumber(value: w.id)] as CFArray
             let spaces = CGSCopySpacesForWindows(cid, 7, arr)?.takeRetainedValue() as? [Int] ?? []
             if out.isHidden || ax.minimized.contains(w.id) {
-                // AX-less hidden shells (Electron) drop after two strikes; a single AX timeout spares real windows (#126).
+                // Hidden Electron apps keep shell windows with no AX backing; two strikes before dropping so one slow AX sweep doesn't eat real windows (#126).
                 if !ax.axBacked.contains(w.id) {
                     if ghostStrikeConfirmed(w.id) { return nil }
                 } else {
                     clearGhostStrike(w.id)
                 }
                 out.isMinimized = ax.minimized.contains(w.id)
-                // No Space claim counts as current, older macOS drops assignments on orderOut (#129).
+                // A window with no Space claim counts as current, older macOS drops the assignment once a window is ordered out (#129).
                 out.isCrossSpace = !spaces.isEmpty && !spaces.contains(where: { metadata.currentSpaces.contains($0) })
                 if let sid = spaces.first {
                     let info = metadata.labels[sid]


### PR DESCRIPTION
Fixes #127, fixes #126, addresses #129, fixes #133.

- #127: the settings model looked up the Sparkle updater via `NSApp.delegate as? AppDelegate`, which is SwiftUI's internal delegate under the app lifecycle, so the cast was always nil. The toggle wrote to nothing and read back the default. The delegate now registers a shared reference at init.
- #126: hidden and minimized windows returned before the ghost-pruning logic, so hidden Electron apps surfaced every orderOut'd shell window as a duplicate. Hidden/minimized windows now require a live AX-backed window.
- #129: the same early return hard-marked hidden/minimized windows as current-Space, making them immune to the cross-Space filter. They now keep their Space claim (no claim counts as current, since older macOS drops assignments on orderOut). They also pick up spaceID/label, so Space representatives count them.
- #133: the selection backfill was clipped to each row while its matched-geometry frame animated between rows, so only the border ring appeared to move. The fills are now rounded rects and the row clip is gone.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs Sparkle updater access, revises hidden/minimized window and Space classification, and adjusts selection rendering.
- Registers a shared AppDelegate reference for updater settings.
- Uses current or cached AX evidence to suppress hidden application shells.
- Annotates hidden/minimized windows with Space metadata.
- Moves selection rounding onto the animated fills.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because genuine hidden windows can still disappear when AX evidence is unavailable before they enter the cache.

The revised hidden-window guard still converts failed, empty, or partial AX results into immediate removal for never-cached windows that cannot satisfy the Space/title fallback.

**Files Needing Attention:** Sources/Switch/WindowEnumerator.swift

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Sources/Switch/AppDelegate.swift | Registers a weak shared delegate reference so SwiftUI settings can access the Sparkle updater. |
| Sources/Switch/SettingsView.swift | Resolves the updater through the explicitly registered AppDelegate instance. |
| Sources/Switch/SwitchView.swift | Replaces row-level clipping with rounded animated selection and hover fills. |
| Sources/Switch/WindowEnumerator.swift | Adds Space-aware hidden-window filtering, but still discards genuine never-cached windows when AX evidence is unavailable. |

</details>

<sub>Reviews (7): Last reviewed commit: ["judge hidden windows by lifetime ax evid..."](https://github.com/sanyam-g/switch/commit/3253ee4bd14466ef121fd8fc262a33882454ef2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52292718)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->