### PR TITLE
Add Simplified Chinese localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Switch
 
+[简体中文](README.zh-CN.md)
+
 A keyboard-driven window switcher for macOS. Like it? [Buy me a coffee →](https://www.paypal.com/paypalme/sanyamg0)
 
 → [switch-dev.sanyamgarg.com](https://switch-dev.sanyamgarg.com)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,63 @@
+# Switch
+
+[English](README.md)
+
+Switch 是一款使用键盘操作的 macOS 窗口切换器。本 fork 已加入简体中文界面，并保留英文作为默认开发语言。
+
+项目主页：[switch-dev.sanyamgarg.com](https://switch-dev.sanyamgarg.com)
+
+## 功能
+
+- `⌘-Tab`：循环切换所有窗口
+- `⌥-\``：循环切换当前应用的窗口
+- 直接输入文字：筛选窗口
+- 数字键 `1–9`：快速选择对应窗口
+- `⌘W`：关闭窗口；`⌘Q`：退出应用；`⌘H`：隐藏应用
+- 回车确认，Esc 取消
+- 按最近使用顺序排列窗口，并在后台预热切换面板
+- 支持跨桌面空间窗口、垂直列表、排除指定应用和保持面板打开模式
+
+## 系统要求
+
+- macOS 14 或更高版本
+- 辅助功能权限
+- 屏幕录制权限（仅在启用窗口缩略图时需要）
+
+## 从源码构建
+
+先安装 Xcode 和 XcodeGen：
+
+```bash
+brew install xcodegen
+```
+
+生成 Xcode 工程：
+
+```bash
+xcodegen generate
+open Switch.xcodeproj
+```
+
+在 Xcode 中选择 `Switch` scheme 后运行。首次启动时，请按引导授予所需权限。
+
+## 安装原版
+
+原作者提供的 Homebrew 安装方式：
+
+```bash
+brew install --cask Sanyam-G/switch/switch
+```
+
+也可以前往[项目主页](https://switch-dev.sanyamgarg.com)下载最新 DMG。请注意，在本 fork 发布独立构建之前，上述渠道安装的是原作者版本。
+
+## 更新
+
+应用使用 Sparkle 提供内置更新检查。可在“设置 → 关于 → 检查更新”中手动检查，也可在设置中关闭后台自动检查。
+
+## 许可证
+
+项目采用 [FSL-1.1-MIT](LICENSE.md) 许可证。版权和原作者信息保持不变。
+
+---
+
+© 2026 Sanyam Garg

--- a/Sources/Switch/AboutWindow.swift
+++ b/Sources/Switch/AboutWindow.swift
@@ -22,7 +22,7 @@ final class AboutWindow {
             backing: .buffered,
             defer: false
         )
-        win.title = "About Switch"
+        win.title = L10n.string("About Switch")
         win.contentMinSize = NSSize(width: 380, height: 360)
         win.contentViewController = host
         win.center()
@@ -68,7 +68,7 @@ struct AboutView: View {
             VStack(spacing: 4) {
                 Text("Switch")
                     .font(.system(size: 22, weight: .semibold))
-                Text("Version \(BuildInfo.versionLine)")
+                Text(L10n.format("Version %@", BuildInfo.versionLine))
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                 if let stamp = BuildInfo.stamp {
@@ -119,7 +119,7 @@ private struct AboutPill: View {
     let title: String
     let url: String
     var body: some View {
-        Link(title, destination: URL(string: url)!)
+        Link(L10n.string(title), destination: URL(string: url)!)
             .font(.system(size: 11, weight: .medium))
             .padding(.horizontal, 11)
             .padding(.vertical, 5)

--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -291,8 +291,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         updaterController.checkForUpdates(nil)
         #else
         let alert = NSAlert()
-        alert.messageText = "Updates not configured"
-        alert.informativeText = "This build doesn't include Sparkle. Visit switch-dev.sanyamgarg.com to download the latest."
+        alert.messageText = L10n.string("Updates not configured")
+        alert.informativeText = L10n.string("This build doesn't include Sparkle. Visit switch-dev.sanyamgarg.com to download the latest.")
         alert.runModal()
         #endif
     }

--- a/Sources/Switch/HotkeyConfig.swift
+++ b/Sources/Switch/HotkeyConfig.swift
@@ -200,10 +200,10 @@ enum HotkeyValidator {
         let mask: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
         let cleaned = flags.intersection(mask)
         if cleaned.intersection([.maskCommand, .maskAlternate, .maskControl]).rawValue == 0 {
-            return "Needs at least one modifier (⌘, ⌥, or ⌃)."
+            return L10n.string("Needs at least one modifier (⌘, ⌥, or ⌃).")
         }
         for (rk, rf) in reserved where rk == keyCode && rf == cleaned {
-            return "That combo is reserved by macOS or common apps."
+            return L10n.string("That combo is reserved by macOS or common apps.")
         }
         return nil
     }
@@ -212,10 +212,10 @@ enum HotkeyValidator {
 enum KeyName {
     /// Human-readable key name (single char where possible, "Tab" / "F1" etc otherwise).
     static func string(for code: UInt16) -> String {
-        if let s = special[code] { return s }
+        if let s = special[code] { return L10n.string(s) }
         // Fall back to NSEvent.charactersByApplyingModifiers for printable keys.
         if let cs = chars(for: code) { return cs.uppercased() }
-        return "Key \(code)"
+        return L10n.format("Key %d", code)
     }
 
     private static let special: [UInt16: String] = [

--- a/Sources/Switch/Localization.swift
+++ b/Sources/Switch/Localization.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum L10n {
+    static func string(_ key: String) -> String {
+        Bundle.main.localizedString(forKey: key, value: key, table: nil)
+    }
+
+    static func format(_ key: String, _ arguments: CVarArg...) -> String {
+        String(format: string(key), locale: Locale.current, arguments: arguments)
+    }
+}

--- a/Sources/Switch/OnboardingView.swift
+++ b/Sources/Switch/OnboardingView.swift
@@ -14,7 +14,7 @@ struct OnboardingView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Switch")
                         .font(.system(size: 16, weight: .semibold))
-                    Text(model.requiresScreenCapture ? "Two permissions before you can switch windows." : "One permission before you can switch windows.")
+                    Text(L10n.string(model.requiresScreenCapture ? "Two permissions before you can switch windows." : "One permission before you can switch windows."))
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
                 }
@@ -69,11 +69,11 @@ struct OnboardingView: View {
                 .font(.system(size: 18))
                 .foregroundStyle(granted ? Color.green : Color.secondary)
             VStack(alignment: .leading, spacing: 1) {
-                Text(name).font(.system(size: 13, weight: .medium))
-                Text(detail).font(.system(size: 11)).foregroundStyle(.secondary)
+                Text(L10n.string(name)).font(.system(size: 13, weight: .medium))
+                Text(L10n.string(detail)).font(.system(size: 11)).foregroundStyle(.secondary)
             }
             Spacer()
-            Button(granted ? "Granted" : "Open Settings", action: open)
+            Button(L10n.string(granted ? "Granted" : "Open Settings"), action: open)
                 .disabled(granted)
         }
         .padding(.horizontal, 12)

--- a/Sources/Switch/Resources/zh-Hans.lproj/InfoPlist.strings
+++ b/Sources/Switch/Resources/zh-Hans.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSAppleEventsUsageDescription" = "Switch 使用辅助功能来聚焦、关闭和移动窗口。";
+"NSScreenCaptureUsageDescription" = "Switch 会获取窗口缩略图，方便你确认将要切换到的窗口。";

--- a/Sources/Switch/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Switch/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,182 @@
+/* Onboarding */
+"Two permissions before you can switch windows." = "还需授予两项权限才能切换窗口。";
+"One permission before you can switch windows." = "还需授予一项权限才能切换窗口。";
+"Accessibility" = "辅助功能";
+"Lets Switch intercept ⌘-Tab and ⌥-`." = "允许 Switch 接管 ⌘-Tab 和 ⌥-` 快捷键。";
+"Screen Recording" = "屏幕录制";
+"Captures live thumbnails of your windows." = "用于获取窗口的实时缩略图。";
+"Optional while thumbnails are disabled." = "关闭缩略图时无需授予。";
+"Ready. Hold ⌘-Tab to switch windows." = "准备就绪。按住 ⌘-Tab 即可切换窗口。";
+"Click Open Settings, then toggle Switch on. This window updates automatically." = "点按“打开设置”，然后启用 Switch。此窗口会自动更新状态。";
+"Continue without thumbnails" = "不使用缩略图并继续";
+"Granted" = "已授权";
+"Open Settings" = "打开设置";
+
+/* Settings tabs and sections */
+"General" = "常规";
+"Picker" = "切换面板";
+"Permissions" = "权限";
+"Appearance" = "外观";
+"About" = "关于";
+"Startup" = "启动";
+"Hotkeys" = "快捷键";
+"Updates" = "更新";
+"Behavior" = "行为";
+"Vertical mode" = "垂直模式";
+"Sizing" = "尺寸";
+"Advanced" = "高级";
+"Cross-Space" = "跨空间";
+"Excluded apps" = "排除的应用";
+"Accent" = "强调色";
+"Background" = "背景";
+
+/* General settings */
+"Launch Switch at login" = "登录时启动 Switch";
+"Run automatically when you sign in to your Mac." = "登录 Mac 时自动运行。";
+"All windows" = "所有窗口";
+"Current app" = "当前应用";
+"Spaces" = "桌面空间";
+"Cycle Spaces. Conflicts with browser tab switching if set to ⌃Tab." = "循环切换桌面空间。若设为 ⌃Tab，会与浏览器标签页切换冲突。";
+"Primary" = "主要";
+"Alternate" = "备用";
+"Not set" = "未设置";
+"Sticky toggle" = "保持模式开关";
+"Clear" = "清除";
+"Clear %@ shortcut" = "清除%@快捷键";
+"Sticky: ⌘W/Q/H · Hold: ⇧⌘W/Q/H · ⇧ reverse" = "保持模式：⌘W/Q/H · 按住：⇧⌘W/Q/H · ⇧ 反向";
+"Reset" = "重置";
+"Check for updates automatically" = "自动检查更新";
+"Look for new versions in the background and offer to install them. Turn off if you update through Homebrew." = "在后台检查新版本并提示安装；若通过 Homebrew 更新，可关闭此项。";
+"Quit Switch" = "退出 Switch";
+"Relaunch any time from Spotlight or your Applications folder." = "可随时通过聚焦搜索或“应用程序”文件夹重新启动。";
+"Quit" = "退出";
+
+/* Picker behavior */
+"Sticky picker" = "保持面板打开";
+"Release ⌘ to leave the picker open. Return to switch, Esc to cancel." = "松开 ⌘ 后面板仍保持打开；按回车切换，按 Esc 取消。";
+"Keyboard only" = "仅使用键盘";
+"Ignore mouse hover and click while the picker is open." = "切换面板打开时忽略鼠标悬停和点击。";
+"Reduce motion" = "减少动态效果";
+"Turn off picker fade, selection movement, and other switcher animations." = "关闭面板淡入淡出、选中项移动等动画效果。";
+"Hide menu bar icon" = "隐藏菜单栏图标";
+"Keep Switch off the menu bar. Open Settings by pressing comma while the picker is open." = "不在菜单栏显示 Switch；面板打开时按逗号键可进入设置。";
+"Type to filter" = "输入文字筛选";
+"Filter windows by typing while the picker is open. When disabled, ⌘W/⌘Q/⌘H work directly." = "面板打开时输入文字即可筛选窗口。关闭后，⌘W/⌘Q/⌘H 可直接使用。";
+"Static order" = "固定排序";
+"Keep windows in the same spot every time instead of sorting by recent use." = "保持窗口位置不变，不再按最近使用时间排序。";
+"Hide minimized and hidden windows" = "隐藏已最小化和已隐藏的窗口";
+"Leave out windows that are minimized to the Dock or belong to hidden apps." = "不显示已最小化到程序坞的窗口，以及已隐藏应用的窗口。";
+"Show number key hints" = "显示数字键提示";
+"Label the first nine windows with the 1-9 key that picks them." = "为前九个窗口标注可直接选择它们的 1–9 数字键。";
+"Include apps with no windows" = "包括没有窗口的应用";
+"Show running Dock apps that don't currently have any windows. Picking one activates the app." = "显示当前没有窗口的运行中程序坞应用；选择后会激活该应用。";
+"Show thumbnails" = "显示缩略图";
+"Capture window previews. Turn off to run without Screen Recording." = "获取窗口预览；关闭后可在没有屏幕录制权限的情况下运行。";
+"Show stoplights on thumbnails" = "在缩略图上显示窗口按钮";
+"Red/yellow/green buttons to close, minimize, or zoom each window. ⌘W closes the selected window either way." = "使用红、黄、绿按钮关闭、最小化或缩放窗口；无论是否开启，⌘W 都可关闭选中窗口。";
+"Show hint strip" = "显示快捷键提示栏";
+"Keyboard shortcut hints at the bottom of the picker." = "在切换面板底部显示快捷键提示。";
+"Show window title first" = "优先显示窗口标题";
+"Put the window title ahead of the app name in each tile and row." = "在每个卡片和列表行中，将窗口标题显示在应用名称之前。";
+
+/* Vertical mode and sizing */
+"Vertical list" = "垂直列表";
+"One window per row instead of a grid." = "每行显示一个窗口，而不是使用网格布局。";
+"Show top header" = "显示顶部栏";
+"Filter text and window count at the top of the picker." = "在切换面板顶部显示筛选文字和窗口数量。";
+"Show preview" = "显示预览";
+"Window thumbnail at the trailing edge of each row." = "在每一行的末尾显示窗口缩略图。";
+"Show stoplights" = "显示窗口按钮";
+"Close/minimize/zoom buttons inside each row." = "在每一行中显示关闭、最小化和缩放按钮。";
+"Columns" = "列数";
+"Number of columns in the grid view. %d" = "网格视图的列数：%d";
+"Thumbnail size" = "缩略图大小";
+"Overall picker size. %dpt" = "切换面板的整体大小：%d 点";
+"App icon size" = "应用图标大小";
+"Size of the app icon on each tile and list row. %dpt" = "每个卡片和列表行中的应用图标大小：%d 点";
+"Reset sizing" = "重置尺寸";
+"Restore columns, thumbnail size, and app icon size." = "恢复默认列数、缩略图大小和应用图标大小。";
+"Picker activation delay" = "面板显示延迟";
+"Hold the hotkey this long before the picker appears. A quick tap switches to your previous window without showing it. %dms" = "按住快捷键达到此时长后才显示面板；快速点按会直接切换到上一个窗口：%d 毫秒";
+"Reverse with Shift tap" = "点按 Shift 反向切换";
+"While holding the hotkey, tap Shift to step backward. ⇧-Tab still works too." = "按住切换快捷键时点按 Shift 可向后切换，⇧-Tab 仍然有效。";
+
+/* Cross-Space and app lists */
+"Show cross-Space windows" = "显示其他空间的窗口";
+"Include windows on other Spaces. Picking one moves it to your current Space." = "包括其他桌面空间中的窗口；选择后会将其移动到当前空间。";
+"Mix by recent use" = "按最近使用混合排序";
+"Sort all windows together by recency instead of grouping by Space." = "将所有窗口按最近使用时间统一排序，不再按桌面空间分组。";
+"Drag to reorder. Unranked apps fall to the bottom alphabetically." = "拖动即可重新排序；未排序的应用会按字母顺序排列在末尾。";
+"No windows open right now." = "当前没有打开的窗口。";
+"Windows from these apps won't appear in the picker." = "这些应用的窗口不会出现在切换面板中。";
+"Nothing excluded." = "尚未排除任何应用。";
+"+ Add app" = "+ 添加应用";
+
+/* Appearance */
+"System" = "系统";
+"Rose" = "玫瑰";
+"Blue" = "蓝色";
+"Mint" = "薄荷";
+"Peach" = "蜜桃";
+"Lavender" = "薰衣草";
+"Mono" = "单色";
+"Light" = "轻度";
+"Medium" = "中度";
+"Heavy" = "重度";
+"Accent shows up in the selection highlight and across this Settings window." = "强调色会用于选中高亮和整个设置窗口。";
+"How much the desktop blurs through the picker background." = "调整桌面透过切换面板背景时的模糊程度。";
+
+/* Permissions */
+"Switch needs Accessibility for the ⌘-Tab hotkey. Screen Recording is only needed when thumbnails are enabled." = "Switch 需要辅助功能权限才能使用 ⌘-Tab 快捷键；仅在启用缩略图时需要屏幕录制权限。";
+"Intercept ⌘-Tab and ⌥-` system-wide." = "在整个系统中接管 ⌘-Tab 和 ⌥-`。";
+"Capture live thumbnails of every window." = "获取每个窗口的实时缩略图。";
+"Open in System Settings" = "在系统设置中打开";
+
+/* Hotkey recorder */
+"Press a key…" = "请按下快捷键…";
+"Needs at least one modifier (⌘, ⌥, or ⌃)." = "至少需要一个修饰键（⌘、⌥ 或 ⌃）。";
+"That combo is reserved by macOS or common apps." = "该组合键已被 macOS 或常用应用保留。";
+"That shortcut is already assigned." = "该快捷键已被分配。";
+"Space" = "空格";
+"Return" = "回车";
+"Delete" = "删除";
+"Fwd Del" = "向前删除";
+"Key %d" = "按键 %d";
+
+/* Picker */
+"MINIMIZED" = "已最小化";
+"HIDDEN" = "已隐藏";
+"NO WINDOWS" = "无窗口";
+"OTHER SPACE" = "其他空间";
+"CURRENT" = "当前";
+"Current" = "当前";
+"No windows" = "没有窗口";
+"No matches" = "没有匹配项";
+"%d spaces" = "%d 个空间";
+"switch space" = "切换空间";
+"switch" = "切换";
+"navigate" = "导航";
+"reverse" = "反向";
+"close" = "关闭";
+"type" = "输入";
+"filter" = "筛选";
+"cancel" = "取消";
+"1 window" = "1 个窗口";
+"%d windows" = "%d 个窗口";
+"%@ · %@" = "%@ · %@";
+"Desktop" = "桌面";
+"Desktop %d" = "桌面 %d";
+"Fullscreen" = "全屏";
+
+/* About, menu, and updates */
+"About Switch" = "关于 Switch";
+"Switch Settings" = "Switch 设置";
+"Settings…" = "设置…";
+"Version %@" = "版本 %@";
+"Keyboard-driven window switcher for macOS." = "为 macOS 打造的键盘驱动窗口切换器。";
+"Website" = "网站";
+"Source" = "源代码";
+"☕ Coffee" = "☕ 请作者喝咖啡";
+"Check for Updates" = "检查更新";
+"Updates not configured" = "未配置更新";
+"This build doesn't include Sparkle. Visit switch-dev.sanyamgarg.com to download the latest." = "此构建未包含 Sparkle。请访问 switch-dev.sanyamgarg.com 下载最新版本。";

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -109,11 +109,11 @@ private enum SettingsTab: String, CaseIterable, Identifiable {
     var id: String { rawValue }
     var label: String {
         switch self {
-        case .general: return "General"
-        case .picker: return "Picker"
-        case .permissions: return "Permissions"
-        case .appearance: return "Appearance"
-        case .about: return "About"
+        case .general: return L10n.string("General")
+        case .picker: return L10n.string("Picker")
+        case .permissions: return L10n.string("Permissions")
+        case .appearance: return L10n.string("Appearance")
+        case .about: return L10n.string("About")
         }
     }
 }
@@ -387,7 +387,7 @@ struct SettingsView: View {
                 section("Sizing") {
                     VStack(spacing: 0) {
                         row(title: "Columns",
-                            detail: "Number of columns in the grid view. \(prefs.gridColumns)") {
+                            detail: L10n.format("Number of columns in the grid view. %d", prefs.gridColumns)) {
                             Slider(value: Binding(
                                 get: { Double(prefs.gridColumns) },
                                 set: { prefs.gridColumns = Int($0.rounded()) }
@@ -397,14 +397,14 @@ struct SettingsView: View {
                         }
                         Divider().opacity(0.4)
                         row(title: "Thumbnail size",
-                            detail: "Overall picker size. \(Int(prefs.thumbnailHeight))pt") {
+                            detail: L10n.format("Overall picker size. %dpt", Int(prefs.thumbnailHeight))) {
                             Slider(value: $prefs.thumbnailHeight, in: 80...300, step: 5)
                                 .frame(width: 140)
                                 .tint(prefs.accent.color)
                         }
                         Divider().opacity(0.4)
                         row(title: "App icon size",
-                            detail: "Size of the app icon on each tile and list row. \(Int(prefs.appIconSize))pt") {
+                            detail: L10n.format("Size of the app icon on each tile and list row. %dpt", Int(prefs.appIconSize))) {
                             Slider(value: $prefs.appIconSize, in: 20...48, step: 2)
                                 .frame(width: 140)
                                 .tint(prefs.accent.color)
@@ -443,7 +443,7 @@ struct SettingsView: View {
         section("Advanced") {
             VStack(spacing: 0) {
                 row(title: "Picker activation delay",
-                    detail: "Hold the hotkey this long before the picker appears. A quick tap switches to your previous window without showing it. \(Int(prefs.pickerActivationDelay))ms") {
+                    detail: L10n.format("Hold the hotkey this long before the picker appears. A quick tap switches to your previous window without showing it. %dms", Int(prefs.pickerActivationDelay))) {
                     Slider(value: $prefs.pickerActivationDelay, in: 0...300, step: 10)
                         .frame(width: 140)
                         .tint(prefs.accent.color)
@@ -521,7 +521,7 @@ struct SettingsView: View {
                 initialBinding: model.stickyToggle ?? HotkeyBinding(keyCode: 0, modifiersRaw: 0),
                 onCapture: { b in applyHotkey(b, replacing: model.stickyToggle) { model.updateStickyToggle($0) } },
                 accent: prefs.accent.color,
-                placeholder: "Not set"
+                placeholder: L10n.string("Not set")
             )
             .frame(width: 180, height: 28)
             if model.stickyToggle != nil {
@@ -761,7 +761,7 @@ struct SettingsView: View {
                 Circle()
                     .fill(prefs.accent.color)
                     .frame(width: 5, height: 5)
-                Text(title.uppercased())
+                Text(L10n.string(title).uppercased())
                     .font(.system(size: 10, weight: .semibold, design: .monospaced))
                     .tracking(1.4)
                     .foregroundStyle(.secondary)
@@ -773,8 +773,8 @@ struct SettingsView: View {
     private func row<Trailing: View>(title: String, detail: String, @ViewBuilder trailing: () -> Trailing) -> some View {
         HStack(alignment: .center, spacing: 14) {
             VStack(alignment: .leading, spacing: 3) {
-                Text(title).font(.system(size: 13, weight: .medium))
-                Text(detail)
+                Text(L10n.string(title)).font(.system(size: 13, weight: .medium))
+                Text(L10n.string(detail))
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -791,7 +791,7 @@ struct SettingsView: View {
                            onAlternateCapture: @escaping (HotkeyBinding?) -> Void) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .top, spacing: 12) {
-                Text(label)
+                Text(L10n.string(label))
                     .font(.system(size: 13, weight: .medium))
                     .frame(width: 100, alignment: .leading)
                 VStack(alignment: .leading, spacing: 6) {
@@ -801,7 +801,7 @@ struct SettingsView: View {
                 Spacer()
             }
             if let detail {
-                Text(detail)
+                Text(L10n.string(detail))
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                     .padding(.leading, 112)
@@ -811,7 +811,7 @@ struct SettingsView: View {
 
     private func hotkeyBindingRow(label: String, binding: HotkeyBinding?, onCapture: @escaping (HotkeyBinding?) -> Void) -> some View {
         HStack(spacing: 8) {
-            Text(label)
+            Text(L10n.string(label))
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
                 .frame(width: 54, alignment: .leading)
@@ -819,7 +819,7 @@ struct SettingsView: View {
                 initialBinding: binding ?? HotkeyBinding(keyCode: 0, modifiersRaw: 0),
                 onCapture: { onCapture($0) },
                 accent: prefs.accent.color,
-                placeholder: "Not set"
+                placeholder: L10n.string("Not set")
             )
             .frame(width: 150, height: 28)
             if binding != nil {
@@ -828,7 +828,7 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
-                .help("Clear \(label.lowercased()) shortcut")
+                .help(L10n.format("Clear %@ shortcut", L10n.string(label).lowercased()))
             }
         }
         .frame(height: 28)
@@ -862,7 +862,7 @@ struct SettingsView: View {
         if let msg = HotkeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags) {
             rejectMessage = msg
         } else if configuredHotkeys.contains(where: { $0 != old && $0.conflicts(with: b) }) {
-            rejectMessage = "That shortcut is already assigned."
+            rejectMessage = L10n.string("That shortcut is already assigned.")
         } else {
             rejectMessage = nil
             save(b)
@@ -914,8 +914,8 @@ struct PermissionsTabView: View {
                 .font(.system(size: 18))
                 .foregroundStyle(granted ? Color.green : Color.orange)
             VStack(alignment: .leading, spacing: 2) {
-                Text(title).font(.system(size: 13, weight: .medium))
-                Text(detail).font(.system(size: 11)).foregroundStyle(.secondary)
+                Text(L10n.string(title)).font(.system(size: 13, weight: .medium))
+                Text(L10n.string(detail)).font(.system(size: 11)).foregroundStyle(.secondary)
             }
             Spacer()
             if !granted {
@@ -1089,7 +1089,7 @@ final class KeyRecorderNSView: NSView {
 
     private func redraw() {
         if recording {
-            label.stringValue = "Press a key…"
+            label.stringValue = L10n.string("Press a key…")
             label.textColor = .secondaryLabelColor
             layer?.borderColor = accentNSColor.cgColor
             layer?.backgroundColor = accentNSColor.withAlphaComponent(0.10).cgColor

--- a/Sources/Switch/SettingsWindow.swift
+++ b/Sources/Switch/SettingsWindow.swift
@@ -32,7 +32,7 @@ final class SettingsWindow {
             backing: .buffered,
             defer: false
         )
-        win.title = "Switch Settings"
+        win.title = L10n.string("Switch Settings")
         win.contentViewController = host
         win.center()
         win.isReleasedWhenClosed = false

--- a/Sources/Switch/StatusBarController.swift
+++ b/Sources/Switch/StatusBarController.swift
@@ -25,17 +25,17 @@ final class StatusBarController {
 
         menu.addItem(.separator())
 
-        let about = NSMenuItem(title: "About Switch", action: #selector(openAbout), keyEquivalent: "")
+        let about = NSMenuItem(title: L10n.string("About Switch"), action: #selector(openAbout), keyEquivalent: "")
         about.target = self
         menu.addItem(about)
 
-        let settings = NSMenuItem(title: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
+        let settings = NSMenuItem(title: L10n.string("Settings…"), action: #selector(openSettings), keyEquivalent: ",")
         settings.target = self
         menu.addItem(settings)
 
         menu.addItem(.separator())
 
-        let quit = NSMenuItem(title: "Quit Switch", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        let quit = NSMenuItem(title: L10n.string("Quit Switch"), action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
         quit.target = NSApp
         menu.addItem(quit)
 

--- a/Sources/Switch/SwitchPreferences.swift
+++ b/Sources/Switch/SwitchPreferences.swift
@@ -16,13 +16,13 @@ final class SwitchPreferences: ObservableObject {
         var id: String { rawValue }
         var label: String {
             switch self {
-            case .system: return "System"
-            case .rose: return "Rose"
-            case .blue: return "Blue"
-            case .mint: return "Mint"
-            case .peach: return "Peach"
-            case .lavender: return "Lavender"
-            case .monochrome: return "Mono"
+            case .system: return L10n.string("System")
+            case .rose: return L10n.string("Rose")
+            case .blue: return L10n.string("Blue")
+            case .mint: return L10n.string("Mint")
+            case .peach: return L10n.string("Peach")
+            case .lavender: return L10n.string("Lavender")
+            case .monochrome: return L10n.string("Mono")
             }
         }
         var color: Color {
@@ -43,9 +43,9 @@ final class SwitchPreferences: ObservableObject {
         var id: String { rawValue }
         var label: String {
             switch self {
-            case .light: return "Light"
-            case .medium: return "Medium"
-            case .heavy: return "Heavy"
+            case .light: return L10n.string("Light")
+            case .medium: return L10n.string("Medium")
+            case .heavy: return L10n.string("Heavy")
             }
         }
         var material: Material {

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -78,10 +78,11 @@ struct SwitchView: View {
     }
 
     private func windowBadgeText(for window: WindowInfo) -> String {
-        if window.isMinimized { return "MINIMIZED" }
-        if window.isHidden { return "HIDDEN" }
-        if window.isWindowless { return "NO WINDOWS" }
-        return window.spaceLabel?.uppercased() ?? "OTHER SPACE"
+        if window.isMinimized { return L10n.string("MINIMIZED") }
+        if window.isHidden { return L10n.string("HIDDEN") }
+        if window.isWindowless { return L10n.string("NO WINDOWS") }
+        if let label = window.spaceLabel { return L10n.string(label).uppercased() }
+        return L10n.string("OTHER SPACE")
     }
 
     private var showHeader: Bool {
@@ -152,7 +153,7 @@ struct SwitchView: View {
             }
             Spacer()
             if !model.filteredWindows.isEmpty {
-                Text(isSpaceMode ? "\(model.filteredWindows.count) spaces" : "\(model.filteredWindows.count)")
+                Text(isSpaceMode ? L10n.format("%d spaces", model.filteredWindows.count) : "\(model.filteredWindows.count)")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.tertiary)
                     .monospacedDigit()
@@ -216,7 +217,7 @@ struct SwitchView: View {
             Image(systemName: model.filterText.isEmpty ? "rectangle.stack" : "magnifyingglass")
                 .font(.system(size: 20, weight: .medium))
                 .foregroundStyle(.tertiary)
-            Text(model.filterText.isEmpty ? "No windows" : "No matches")
+            Text(L10n.string(model.filterText.isEmpty ? "No windows" : "No matches"))
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.secondary)
         }
@@ -298,7 +299,7 @@ struct SwitchView: View {
 
     private func hint(_ key: String, _ label: String) -> some View {
         HStack(spacing: 5) {
-            Text(key)
+            Text(L10n.string(key))
                 .font(.system(size: 10, weight: .semibold, design: .monospaced))
                 .tracking(1)
                 .foregroundStyle(.primary.opacity(0.85))
@@ -308,12 +309,12 @@ struct SwitchView: View {
                     RoundedRectangle(cornerRadius: 3, style: .continuous)
                         .fill(Color.white.opacity(0.10))
                 )
-            Text(label)
+            Text(L10n.string(label))
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
         }
         .fixedSize()
-        .help(label)
+        .help(L10n.string(label))
     }
 
     private var gridColumns: [GridItem] {
@@ -449,7 +450,7 @@ struct SwitchView: View {
             }
             if isSpaceMode {
                 if window.spaceLabel == "Current" {
-                    capsuleBadge("CURRENT")
+                    capsuleBadge(L10n.string("CURRENT"))
                 }
             } else {
                 windowBadge(for: window)

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -287,13 +287,13 @@ enum WindowEnumerator {
             let sorted = WindowMRU.sorted(windows, frontmost: nil)
             guard let target = sorted.first else { return nil }
             let apps = Array(NSOrderedSet(array: sorted.map(\.appName)).compactMap { $0 as? String }).prefix(3)
-            let suffix = sorted.count == 1 ? "1 window" : "\(sorted.count) windows"
-            let detail = apps.isEmpty ? suffix : "\(suffix) · \(apps.joined(separator: ", "))"
+            let suffix = sorted.count == 1 ? L10n.string("1 window") : L10n.format("%d windows", sorted.count)
+            let detail = apps.isEmpty ? suffix : L10n.format("%@ · %@", suffix, apps.joined(separator: ", "))
             let info = metadata.labels[sid]
             return WindowInfo(
                 id: target.id,
                 pid: target.pid,
-                appName: info?.label ?? "Desktop",
+                appName: info?.label ?? L10n.string("Desktop"),
                 title: detail,
                 bounds: target.bounds,
                 spaceID: sid,
@@ -326,9 +326,9 @@ enum WindowEnumerator {
                 let type = space["type"] as? Int ?? 0
                 if type == 0 {
                     desktop += 1
-                    labels[id] = ("Desktop \(desktop)", false)
+                    labels[id] = (L10n.format("Desktop %d", desktop), false)
                 } else {
-                    labels[id] = ("Fullscreen", true)
+                    labels[id] = (L10n.string("Fullscreen"), true)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- add Simplified Chinese localization for onboarding, settings, the menu bar, window-picker badges and hints, permissions, hotkey validation, updates, and the About window
- add a small localization helper for runtime strings and formatted values that SwiftUI cannot localize automatically
- add localized privacy usage descriptions through `InfoPlist.strings`
- add a Simplified Chinese README while keeping English as the development language and fallback

## Implementation notes

- English source strings remain the localization keys, which keeps the existing UI unchanged for other locales
- dynamic AppKit and model-generated strings use `L10n.string` or `L10n.format`
- XcodeGen detects `zh-Hans.lproj` and includes both string files in the application resources

## Validation

- `plutil -lint Sources/Switch/Resources/zh-Hans.lproj/Localizable.strings Sources/Switch/Resources/zh-Hans.lproj/InfoPlist.strings`
- `git diff --check`
- XcodeGen project generation and resource membership inspection
- Release build on Apple Silicon with Sparkle 2.9.2
- manual launch and visual check under the Simplified Chinese locale

## Disclosure

This implementation was prepared with Codex assistance and reviewed and tested locally by the fork owner.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Simplified Chinese localization while retaining English source strings as fallback keys.
- Introduces a localization helper for AppKit and dynamically formatted strings.
- Localizes onboarding, settings, picker, menu-bar, hotkey, permissions, update, and About surfaces.
- Adds localized privacy descriptions and a Simplified Chinese README.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The localization helper falls back to existing English keys, resources are included through the source-tree project configuration, format placeholders align with their callers, and localized Space display values do not affect ID-based routing.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Sources/Switch/Localization.swift | Adds straightforward bundle lookup and locale-aware formatting helpers with English-key fallback behavior. |
| Sources/Switch/Resources/zh-Hans.lproj/Localizable.strings | Supplies Simplified Chinese translations matching the newly localized runtime surfaces and format placeholders. |
| Sources/Switch/Resources/zh-Hans.lproj/InfoPlist.strings | Adds localized privacy usage descriptions for the existing permission keys. |
| Sources/Switch/SettingsView.swift | Routes dynamic settings labels, descriptions, validation messages, and formatted values through localization. |
| Sources/Switch/SwitchView.swift | Localizes picker badges, empty states, counts, and hint-strip labels without changing selection behavior. |
| Sources/Switch/WindowEnumerator.swift | Localizes generated Space labels and counts while retaining ID-based space routing. |
| Sources/Switch/HotkeyConfig.swift | Localizes validation reasons and human-readable key labels without changing hotkey validation. |
| Sources/Switch/AboutWindow.swift | Localizes the About window title, version line, and link labels. |
| Sources/Switch/OnboardingView.swift | Localizes runtime-selected permission messaging and row content. |
| Sources/Switch/StatusBarController.swift | Localizes AppKit menu-item titles while preserving their actions and shortcuts. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Simplified Chinese localizatio..."](https://github.com/sanyam-g/switch/commit/461c5eb16e8b25e5f87dd0f4e23eb9b705b9b9c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53286160)</sub>

<!-- /greptile_comment -->