### PR TITLE
Add H J K L navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Or quit Switch and drag `Switch.app` from `/Applications` to the Trash.
 - ⌘-Tab cycles all windows
 - ⌥-` cycles within the current app
 - type to filter inline
+- ←↑↓→ or H J K L navigate
 - 1-9 (or numpad) picks a tile
 - ⌘W close window, ⌘Q quit app, ⌘H hide app
 - ↵ commits, Esc cancels

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or quit Switch and drag `Switch.app` from `/Applications` to the Trash.
 - ⌘-Tab cycles all windows
 - ⌥-` cycles within the current app
 - type to filter inline
-- ←↑↓→ or H J K L navigate
+- ←↑↓→ navigate; H J K L via Settings → Vim navigation (turns off type to filter)
 - 1-9 (or numpad) picks a tile
 - ⌘W close window, ⌘Q quit app, ⌘H hide app
 - ↵ commits, Esc cancels

--- a/Sources/Switch/HotkeyManager.swift
+++ b/Sources/Switch/HotkeyManager.swift
@@ -52,6 +52,9 @@ final class HotkeyManager {
     private static let kcW: CGKeyCode = 13
     private static let kcQ: CGKeyCode = 12
     private static let kcH: CGKeyCode = 4
+    private static let kcJ: CGKeyCode = 38
+    private static let kcK: CGKeyCode = 40
+    private static let kcL: CGKeyCode = 37
     private static let kcComma: CGKeyCode = 43
     private static let kcDigits: [CGKeyCode] = [18, 19, 20, 21, 23, 22, 26, 28, 25]
     private static let kcKeypadDigits: [CGKeyCode] = [83, 84, 85, 86, 87, 88, 89, 91, 92]
@@ -469,11 +472,11 @@ final class HotkeyManager {
 
     private func arrowDirection(for kc: CGKeyCode) -> Direction? {
         switch kc {
-        case Self.kcLeftArrow:  return .left
-        case Self.kcRightArrow: return .right
-        case Self.kcDownArrow:  return .down
-        case Self.kcUpArrow:    return .up
-        default:                return nil
+        case Self.kcLeftArrow, Self.kcH:  return .left
+        case Self.kcRightArrow, Self.kcL: return .right
+        case Self.kcDownArrow, Self.kcJ:  return .down
+        case Self.kcUpArrow, Self.kcK:    return .up
+        default:                          return nil
         }
     }
 

--- a/Sources/Switch/HotkeyManager.swift
+++ b/Sources/Switch/HotkeyManager.swift
@@ -263,7 +263,9 @@ final class HotkeyManager {
 
             if armedMode != nil {
                 let sticky = UserDefaults.standard.bool(forKey: SwitchPreferences.stickyModeKey)
-                let typeToFilter = (UserDefaults.standard.object(forKey: SwitchPreferences.typeToFilterKey) as? Bool) ?? true
+                let vimNavigation = UserDefaults.standard.bool(forKey: SwitchPreferences.vimNavigationKey)
+                var typeToFilter = (UserDefaults.standard.object(forKey: SwitchPreferences.typeToFilterKey) as? Bool) ?? true
+                if vimNavigation { typeToFilter = false }
                 let actionModifierMatches = cmd && (sticky || !typeToFilter || shift)
                 if kc == Self.kcEscape {
                     clearArmed()
@@ -318,7 +320,7 @@ final class HotkeyManager {
                     }
                     return nil
                 }
-                if let direction = arrowDirection(for: kc) {
+                if let direction = arrowDirection(for: kc, vim: vimNavigation) {
                     DispatchQueue.main.async { [weak self] in
                         self?.onNavigate?(direction)
                     }
@@ -470,12 +472,16 @@ final class HotkeyManager {
         return nil
     }
 
-    private func arrowDirection(for kc: CGKeyCode) -> Direction? {
+    private func arrowDirection(for kc: CGKeyCode, vim: Bool) -> Direction? {
         switch kc {
-        case Self.kcLeftArrow, Self.kcH:  return .left
-        case Self.kcRightArrow, Self.kcL: return .right
-        case Self.kcDownArrow, Self.kcJ:  return .down
-        case Self.kcUpArrow, Self.kcK:    return .up
+        case Self.kcLeftArrow:            return .left
+        case Self.kcRightArrow:           return .right
+        case Self.kcDownArrow:            return .down
+        case Self.kcUpArrow:              return .up
+        case Self.kcH where vim:          return .left
+        case Self.kcL where vim:          return .right
+        case Self.kcJ where vim:          return .down
+        case Self.kcK where vim:          return .up
         default:                          return nil
         }
     }

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -283,11 +283,21 @@ struct SettingsView: View {
                                 .tint(prefs.accent.color)
                         }
                         Divider().opacity(0.4)
+                        row(title: "Vim navigation",
+                            detail: "Use H J K L to move the selection, same as the arrow keys. Turns off type to filter.") {
+                            Toggle("", isOn: $prefs.vimNavigation)
+                                .labelsHidden().toggleStyle(.switch)
+                                .tint(prefs.accent.color)
+                        }
+                        Divider().opacity(0.4)
                         row(title: "Type to filter",
-                            detail: "Filter windows by typing while the picker is open. When disabled, ⌘W/⌘Q/⌘H work directly.") {
+                            detail: prefs.vimNavigation
+                                ? "Unavailable while Vim navigation is on. H J K L move the selection instead of typing a filter."
+                                : "Filter windows by typing while the picker is open. When disabled, ⌘W/⌘Q/⌘H work directly.") {
                             Toggle("", isOn: $prefs.typeToFilter)
                                 .labelsHidden().toggleStyle(.switch)
                                 .tint(prefs.accent.color)
+                                .disabled(prefs.vimNavigation)
                         }
                         Divider().opacity(0.4)
                         row(title: "Static order",

--- a/Sources/Switch/SwitchPreferences.swift
+++ b/Sources/Switch/SwitchPreferences.swift
@@ -145,7 +145,17 @@ final class SwitchPreferences: ObservableObject {
     }
 
     @Published var typeToFilter: Bool {
-        didSet { UserDefaults.standard.set(typeToFilter, forKey: SwitchPreferences.typeToFilterKey) }
+        didSet {
+            UserDefaults.standard.set(typeToFilter, forKey: SwitchPreferences.typeToFilterKey)
+            if typeToFilter && vimNavigation { vimNavigation = false }
+        }
+    }
+
+    @Published var vimNavigation: Bool {
+        didSet {
+            UserDefaults.standard.set(vimNavigation, forKey: SwitchPreferences.vimNavigationKey)
+            if vimNavigation && typeToFilter { typeToFilter = false }
+        }
     }
 
     @Published var thumbnailHeight: Double {
@@ -201,6 +211,7 @@ final class SwitchPreferences: ObservableObject {
     nonisolated static let verticalShowHeaderKey = "switch.verticalShowHeader"
     nonisolated static let showHintStripKey = "switch.showHintStrip"
     nonisolated static let typeToFilterKey = "switch.typeToFilter"
+    nonisolated static let vimNavigationKey = "switch.vimNavigation"
     nonisolated static let thumbnailHeightKey = "switch.thumbnailHeight"
     nonisolated static let appIconSizeKey = "switch.appIconSize"
     nonisolated static let gridColumnsKey = "switch.gridColumns"
@@ -232,6 +243,11 @@ final class SwitchPreferences: ObservableObject {
         verticalShowHeader = (UserDefaults.standard.object(forKey: SwitchPreferences.verticalShowHeaderKey) as? Bool) ?? true
         showHintStrip = (UserDefaults.standard.object(forKey: SwitchPreferences.showHintStripKey) as? Bool) ?? true
         typeToFilter = (UserDefaults.standard.object(forKey: SwitchPreferences.typeToFilterKey) as? Bool) ?? true
+        vimNavigation = UserDefaults.standard.bool(forKey: SwitchPreferences.vimNavigationKey)
+        if vimNavigation {
+            typeToFilter = false
+            UserDefaults.standard.set(false, forKey: SwitchPreferences.typeToFilterKey)
+        }
         thumbnailHeight = (UserDefaults.standard.object(forKey: SwitchPreferences.thumbnailHeightKey) as? Double) ?? Self.defaultThumbnailHeight
         appIconSize = (UserDefaults.standard.object(forKey: SwitchPreferences.appIconSizeKey) as? Double) ?? Self.defaultAppIconSize
         gridColumns = (UserDefaults.standard.object(forKey: SwitchPreferences.gridColumnsKey) as? Int) ?? Self.defaultGridColumns

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -239,7 +239,10 @@ struct SwitchView: View {
     }
 
     private var navKey: String {
-        (prefs.verticalList || isSpaceMode) ? "↑↓ / jk" : "←↑↓→ / hjkl"
+        if prefs.verticalList || isSpaceMode {
+            return prefs.vimNavigation ? "↑↓ / jk" : "↑↓"
+        }
+        return prefs.vimNavigation ? "←↑↓→ / hjkl" : "←↑↓→"
     }
 
     private var closeKey: String {

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -239,7 +239,7 @@ struct SwitchView: View {
     }
 
     private var navKey: String {
-        (prefs.verticalList || isSpaceMode) ? "↑↓" : "←↑↓→"
+        (prefs.verticalList || isSpaceMode) ? "↑↓ / jk" : "←↑↓→ / hjkl"
     }
 
     private var closeKey: String {


### PR DESCRIPTION
## Summary
- Map H/J/K/L onto the existing arrow-key navigation path
- ⌘H still hides the selected app
- Document the keys in the picker hint and README

Closes #141

## Test plan
- [ ] Open the picker and move with H J K L; selection should match ← ↓ ↑ →
- [ ] Confirm the same in vertical list (J/K only need to move)
- [ ] Confirm ⌘H still hides
- [ ] Confirm ↵ / Esc / type-to-filter still work

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds optional H/J/K/L picker navigation while preserving Command-H and making Vim navigation mutually exclusive with type-to-filter.
- Adds and persists the Vim navigation preference.
- Routes H/J/K/L through existing directional navigation.
- Updates settings, picker hints, and README documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Sources/Switch/HotkeyManager.swift | Adds preference-aware Vim key routing while retaining the earlier Command-H hide branch. |
| Sources/Switch/SwitchPreferences.swift | Persists Vim navigation and enforces mutual exclusion with type-to-filter. |
| Sources/Switch/SettingsView.swift | Exposes Vim navigation and disables the incompatible filtering toggle while active. |
| Sources/Switch/SwitchView.swift | Updates picker navigation hints according to layout and Vim preference. |
| README.md | Documents optional Vim navigation and its interaction with type-to-filter. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Make H J K L navigation a settings toggl..."](https://github.com/sanyam-g/switch/commit/f318e4d87d6c3df02cf3f4a4558132545910d79e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53879512)</sub>

<!-- /greptile_comment -->