### PR TITLE
Add Simplified Chinese localization with String Catalogs

### DIFF
--- a/Sources/Switch/AboutWindow.swift
+++ b/Sources/Switch/AboutWindow.swift
@@ -22,7 +22,7 @@ final class AboutWindow {
             backing: .buffered,
             defer: false
         )
-        win.title = "About Switch"
+        win.title = String(localized: "About Switch", comment: "About window title")
         win.contentMinSize = NSSize(width: 380, height: 360)
         win.contentViewController = host
         win.center()
@@ -66,9 +66,9 @@ struct AboutView: View {
                     .shadow(color: .black.opacity(0.35), radius: 8, y: 4)
             }
             VStack(spacing: 4) {
-                Text("Switch")
+                Text(verbatim: "Switch")
                     .font(.system(size: 22, weight: .semibold))
-                Text("Version \(BuildInfo.versionLine)")
+                Text("Version \(BuildInfo.versionLine)", comment: "About window version line")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                 if let stamp = BuildInfo.stamp {
@@ -78,7 +78,7 @@ struct AboutView: View {
                         .textSelection(.enabled)
                 }
             }
-            Text("Keyboard-driven window switcher for macOS.")
+            Text("Keyboard-driven window switcher for macOS.", comment: "About window tagline")
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -94,7 +94,7 @@ struct AboutView: View {
                 AboutWindow.shared.dropLevelForDialog()
                 NotificationCenter.default.post(name: .switchCheckForUpdates, object: nil)
             } label: {
-                Text("Check for Updates")
+                Text("Check for Updates", comment: "About window update button")
                     .font(.system(size: 11, weight: .medium))
                     .padding(.horizontal, 12)
                     .padding(.vertical, 5)
@@ -105,7 +105,7 @@ struct AboutView: View {
             .buttonStyle(.plain)
 
             Spacer(minLength: 0)
-            Text("© 2026 Sanyam Garg")
+            Text("© 2026 Sanyam Garg", comment: "About window copyright")
                 .font(.system(size: 10))
                 .foregroundStyle(.tertiary)
                 .padding(.bottom, 12)
@@ -116,11 +116,13 @@ struct AboutView: View {
 }
 
 private struct AboutPill: View {
-    let title: String
+    let title: LocalizedStringResource
     let url: String
     var body: some View {
-        Link(title, destination: URL(string: url)!)
-            .font(.system(size: 11, weight: .medium))
+        Link(destination: URL(string: url)!) {
+            Text(title)
+        }
+        .font(.system(size: 11, weight: .medium))
             .padding(.horizontal, 11)
             .padding(.vertical, 5)
             .background(Color.primary.opacity(0.06))

--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -291,8 +291,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         updaterController.checkForUpdates(nil)
         #else
         let alert = NSAlert()
-        alert.messageText = "Updates not configured"
-        alert.informativeText = "This build doesn't include Sparkle. Visit switch-dev.sanyamgarg.com to download the latest."
+        alert.messageText = String(localized: "Updates not configured", comment: "Alert when Sparkle is missing")
+        alert.informativeText = String(localized: "This build doesn't include Sparkle. Visit switch-dev.sanyamgarg.com to download the latest.", comment: "Alert body when Sparkle is missing")
         alert.runModal()
         #endif
     }
@@ -307,7 +307,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 backing: .buffered,
                 defer: false
             )
-            win.title = "Switch"
+            win.title = String(localized: "Switch", comment: "Brand name; do not translate")
             win.contentViewController = host
             win.center()
             win.isReleasedWhenClosed = false

--- a/Sources/Switch/HotkeyConfig.swift
+++ b/Sources/Switch/HotkeyConfig.swift
@@ -200,10 +200,10 @@ enum HotkeyValidator {
         let mask: CGEventFlags = [.maskCommand, .maskAlternate, .maskControl, .maskShift]
         let cleaned = flags.intersection(mask)
         if cleaned.intersection([.maskCommand, .maskAlternate, .maskControl]).rawValue == 0 {
-            return "Needs at least one modifier (⌘, ⌥, or ⌃)."
+            return String(localized: "Needs at least one modifier (⌘, ⌥, or ⌃).", comment: "Hotkey rejected: no modifier")
         }
         for (rk, rf) in reserved where rk == keyCode && rf == cleaned {
-            return "That combo is reserved by macOS or common apps."
+            return String(localized: "That combo is reserved by macOS or common apps.", comment: "Hotkey rejected: reserved combo")
         }
         return nil
     }
@@ -215,18 +215,18 @@ enum KeyName {
         if let s = special[code] { return s }
         // Fall back to NSEvent.charactersByApplyingModifiers for printable keys.
         if let cs = chars(for: code) { return cs.uppercased() }
-        return "Key \(code)"
+        return String(localized: "Key \(Int(code))", comment: "Unknown key code fallback")
     }
 
     private static let special: [UInt16: String] = [
-        48: "Tab",
-        49: "Space",
+        48: String(localized: "Tab", comment: "Key name"),
+        49: String(localized: "Space", comment: "Key name"),
         50: "`",
-        53: "Esc",
-        36: "Return",
-        76: "Enter",
-        51: "Delete",
-        117: "Fwd Del",
+        53: String(localized: "Esc", comment: "Key name"),
+        36: String(localized: "Return", comment: "Key name"),
+        76: String(localized: "Enter", comment: "Key name"),
+        51: String(localized: "Delete", comment: "Key name"),
+        117: String(localized: "Fwd Del", comment: "Forward delete key name"),
         123: "←", 124: "→", 125: "↓", 126: "↑",
         122: "F1", 120: "F2", 99: "F3", 118: "F4",
         96: "F5", 97: "F6", 98: "F7", 100: "F8",

--- a/Sources/Switch/OnboardingView.swift
+++ b/Sources/Switch/OnboardingView.swift
@@ -12,9 +12,11 @@ struct OnboardingView: View {
                         .frame(width: 56, height: 56)
                 }
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Switch")
+                    Text(verbatim: "Switch")
                         .font(.system(size: 16, weight: .semibold))
-                    Text(model.requiresScreenCapture ? "Two permissions before you can switch windows." : "One permission before you can switch windows.")
+                    Text(model.requiresScreenCapture
+                         ? LocalizedStringResource("Two permissions before you can switch windows.", comment: "Onboarding subtitle when thumbnails need Screen Recording")
+                         : LocalizedStringResource("One permission before you can switch windows.", comment: "Onboarding subtitle when only Accessibility is required"))
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
                 }
@@ -30,7 +32,9 @@ struct OnboardingView: View {
                 )
                 row(
                     name: "Screen Recording",
-                    detail: model.requiresScreenCapture ? "Captures live thumbnails of your windows." : "Optional while thumbnails are disabled.",
+                    detail: model.requiresScreenCapture
+                        ? LocalizedStringResource("Captures live thumbnails of your windows.", comment: "Onboarding Screen Recording detail")
+                        : LocalizedStringResource("Optional while thumbnails are disabled.", comment: "Onboarding Screen Recording detail when optional"),
                     granted: model.screenCapture,
                     open: model.openScreenCapture
                 )
@@ -43,7 +47,7 @@ struct OnboardingView: View {
                         .foregroundStyle(.green)
                         .font(.system(size: 12, weight: .medium))
                 } else {
-                    Text("Click Open Settings, then toggle Switch on. This window updates automatically.")
+                    Text("Click Open Settings, then toggle Switch on. This window updates automatically.", comment: "Onboarding waiting hint")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                 }
@@ -63,7 +67,7 @@ struct OnboardingView: View {
         .onDisappear { model.stopPolling() }
     }
 
-    private func row(name: String, detail: String, granted: Bool, open: @escaping () -> Void) -> some View {
+    private func row(name: LocalizedStringResource, detail: LocalizedStringResource, granted: Bool, open: @escaping () -> Void) -> some View {
         HStack(spacing: 12) {
             Image(systemName: granted ? "checkmark.circle.fill" : "circle.dashed")
                 .font(.system(size: 18))
@@ -73,8 +77,12 @@ struct OnboardingView: View {
                 Text(detail).font(.system(size: 11)).foregroundStyle(.secondary)
             }
             Spacer()
-            Button(granted ? "Granted" : "Open Settings", action: open)
-                .disabled(granted)
+            if granted {
+                Button("Granted", action: open)
+                    .disabled(true)
+            } else {
+                Button("Open Settings", action: open)
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)

--- a/Sources/Switch/Resources/InfoPlist.xcstrings
+++ b/Sources/Switch/Resources/InfoPlist.xcstrings
@@ -1,0 +1,40 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "NSAppleEventsUsageDescription": {
+      "comment": "Info.plist Accessibility usage",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch uses Accessibility to focus, close, and move windows."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch 使用辅助功能来聚焦、关闭和移动窗口。"
+          }
+        }
+      }
+    },
+    "NSScreenCaptureUsageDescription": {
+      "comment": "Info.plist Screen Recording usage",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch captures window thumbnails so you can see what you're switching to."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch 会捕获窗口缩略图，方便你看清要切换到的窗口。"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Sources/Switch/Resources/Localizable.xcstrings
+++ b/Sources/Switch/Resources/Localizable.xcstrings
@@ -1,0 +1,2859 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "Switch": {
+      "comment": "Brand name; do not translate",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch"
+          }
+        }
+      },
+      "shouldTranslate": false
+    },
+    "General": {
+      "comment": "Settings tab",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通用"
+          }
+        }
+      }
+    },
+    "Picker": {
+      "comment": "Settings tab",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Picker"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择器"
+          }
+        }
+      }
+    },
+    "Permissions": {
+      "comment": "Settings tab",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限"
+          }
+        }
+      }
+    },
+    "Appearance": {
+      "comment": "Settings tab",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appearance"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外观"
+          }
+        }
+      }
+    },
+    "About": {
+      "comment": "Settings tab",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于"
+          }
+        }
+      }
+    },
+    "Language": {
+      "comment": "Settings section and row title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言"
+          }
+        }
+      }
+    },
+    "Follows System Settings. Restart Switch after changing.": {
+      "comment": "Language row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Follows System Settings. Restart Switch after changing."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跟随系统设置。更改后请重新启动 Switch。"
+          }
+        }
+      }
+    },
+    "Open System Settings": {
+      "comment": "Button to open macOS Language settings",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open System Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开系统设置"
+          }
+        }
+      }
+    },
+    "Startup": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Startup"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动"
+          }
+        }
+      }
+    },
+    "Launch Switch at login": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch Switch at login"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录时打开 Switch"
+          }
+        }
+      }
+    },
+    "Run automatically when you sign in to your Mac.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run automatically when you sign in to your Mac."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录 Mac 后自动运行。"
+          }
+        }
+      }
+    },
+    "Hotkeys": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hotkeys"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键"
+          }
+        }
+      }
+    },
+    "All windows": {
+      "comment": "Hotkey row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All windows"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部窗口"
+          }
+        }
+      }
+    },
+    "Current app": {
+      "comment": "Hotkey row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current app"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前应用"
+          }
+        }
+      }
+    },
+    "Spaces": {
+      "comment": "Hotkey row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spaces"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空间"
+          }
+        }
+      }
+    },
+    "Cycle Spaces. Conflicts with browser tab switching if set to ⌃Tab.": {
+      "comment": "Spaces hotkey help",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cycle Spaces. Conflicts with browser tab switching if set to ⌃Tab."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "循环切换空间。设为 ⌃Tab 时会与浏览器标签页快捷键冲突。"
+          }
+        }
+      }
+    },
+    "Sticky: ⌘W/Q/H · Hold: ⇧⌘W/Q/H · ⇧ reverse": {
+      "comment": "Hotkey help; keep glyphs",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sticky: ⌘W/Q/H · Hold: ⇧⌘W/Q/H · ⇧ reverse"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘滞：⌘W/Q/H · 按住：⇧⌘W/Q/H · ⇧ 反向"
+          }
+        }
+      }
+    },
+    "Reset": {
+      "comment": "Reset button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还原"
+          }
+        }
+      }
+    },
+    "Sticky toggle": {
+      "comment": "Hotkey row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sticky toggle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘滞开关"
+          }
+        }
+      }
+    },
+    "Primary": {
+      "comment": "Primary hotkey label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primary"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主要"
+          }
+        }
+      }
+    },
+    "Alternate": {
+      "comment": "Alternate hotkey label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternate"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备用"
+          }
+        }
+      }
+    },
+    "Clear primary shortcut": {
+      "comment": "Help for clearing primary hotkey",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear primary shortcut"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除主要快捷键"
+          }
+        }
+      }
+    },
+    "Clear alternate shortcut": {
+      "comment": "Help for clearing alternate hotkey",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear alternate shortcut"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除备用快捷键"
+          }
+        }
+      }
+    },
+    "Not set": {
+      "comment": "Empty hotkey placeholder",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not set"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未设置"
+          }
+        }
+      }
+    },
+    "Press a key…": {
+      "comment": "Hotkey recorder prompt",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Press a key…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请按键…"
+          }
+        }
+      }
+    },
+    "Clear": {
+      "comment": "Clear sticky toggle",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除"
+          }
+        }
+      }
+    },
+    "That shortcut is already assigned.": {
+      "comment": "Hotkey already in use",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "That shortcut is already assigned."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该快捷键已被占用。"
+          }
+        }
+      }
+    },
+    "Updates": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "Check for updates automatically": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for updates automatically"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动检查更新"
+          }
+        }
+      }
+    },
+    "Look for new versions in the background and offer to install them. Turn off if you update through Homebrew.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Look for new versions in the background and offer to install them. Turn off if you update through Homebrew."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在后台查找新版本并提示安装。若通过 Homebrew 更新，请关闭。"
+          }
+        }
+      }
+    },
+    "Quit Switch": {
+      "comment": "Quit row and menu item",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit Switch"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出 Switch"
+          }
+        }
+      }
+    },
+    "Relaunch any time from Spotlight or your Applications folder.": {
+      "comment": "Quit row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relaunch any time from Spotlight or your Applications folder."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "之后可从聚焦或“应用程序”文件夹再次打开。"
+          }
+        }
+      }
+    },
+    "Quit": {
+      "comment": "Quit button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
+          }
+        }
+      }
+    },
+    "Behavior": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Behavior"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行为"
+          }
+        }
+      }
+    },
+    "Sticky picker": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sticky picker"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘滞选择器"
+          }
+        }
+      }
+    },
+    "Release ⌘ to leave the picker open. Return to switch, Esc to cancel.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release ⌘ to leave the picker open. Return to switch, Esc to cancel."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "松开 ⌘ 后选择器保持打开。Return 切换，Esc 取消。"
+          }
+        }
+      }
+    },
+    "Keyboard only": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard only"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅键盘"
+          }
+        }
+      }
+    },
+    "Ignore mouse hover and click while the picker is open.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore mouse hover and click while the picker is open."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择器打开时忽略鼠标悬停和点击。"
+          }
+        }
+      }
+    },
+    "Reduce motion": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reduce motion"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "减少动态效果"
+          }
+        }
+      }
+    },
+    "Turn off picker fade, selection movement, and other switcher animations.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn off picker fade, selection movement, and other switcher animations."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭选择器淡入淡出、选中移动及其他切换动画。"
+          }
+        }
+      }
+    },
+    "Hide menu bar icon": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide menu bar icon"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏菜单栏图标"
+          }
+        }
+      }
+    },
+    "Keep Switch off the menu bar. Open Settings by pressing comma while the picker is open.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Switch off the menu bar. Open Settings by pressing comma while the picker is open."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不在菜单栏显示 Switch。选择器打开时按逗号可打开设置。"
+          }
+        }
+      }
+    },
+    "Type to filter": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type to filter"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入以过滤"
+          }
+        }
+      }
+    },
+    "Filter windows by typing while the picker is open. When disabled, ⌘W/⌘Q/⌘H work directly.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter windows by typing while the picker is open. When disabled, ⌘W/⌘Q/⌘H work directly."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择器打开时可通过输入过滤窗口。关闭后 ⌘W/⌘Q/⌘H 可直接使用。"
+          }
+        }
+      }
+    },
+    "Static order": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Static order"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定顺序"
+          }
+        }
+      }
+    },
+    "Keep windows in the same spot every time instead of sorting by recent use.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep windows in the same spot every time instead of sorting by recent use."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "窗口位置固定，不按最近使用排序。"
+          }
+        }
+      }
+    },
+    "Hide minimized and hidden windows": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide minimized and hidden windows"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏已最小化与已隐藏的窗口"
+          }
+        }
+      }
+    },
+    "Leave out windows that are minimized to the Dock or belong to hidden apps.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leave out windows that are minimized to the Dock or belong to hidden apps."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不列出已最小化到程序坞或属于已隐藏应用的窗口。"
+          }
+        }
+      }
+    },
+    "Show number key hints": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show number key hints"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示数字键提示"
+          }
+        }
+      }
+    },
+    "Label the first nine windows with the 1-9 key that picks them.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Label the first nine windows with the 1-9 key that picks them."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "为前九个窗口标上 1–9 选择键。"
+          }
+        }
+      }
+    },
+    "Include apps with no windows": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include apps with no windows"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "包含无窗口的应用"
+          }
+        }
+      }
+    },
+    "Show running Dock apps that don't currently have any windows. Picking one activates the app.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show running Dock apps that don't currently have any windows. Picking one activates the app."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示正在运行但暂无窗口的程序坞应用。选中后会激活该应用。"
+          }
+        }
+      }
+    },
+    "Show thumbnails": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show thumbnails"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示缩略图"
+          }
+        }
+      }
+    },
+    "Capture window previews. Turn off to run without Screen Recording.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture window previews. Turn off to run without Screen Recording."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕获窗口预览。关闭后无需“屏幕录制”权限。"
+          }
+        }
+      }
+    },
+    "Show stoplights on thumbnails": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show stoplights on thumbnails"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在缩略图上显示红绿灯"
+          }
+        }
+      }
+    },
+    "Red/yellow/green buttons to close, minimize, or zoom each window. ⌘W closes the selected window either way.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Red/yellow/green buttons to close, minimize, or zoom each window. ⌘W closes the selected window either way."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "红/黄/绿按钮用于关闭、最小化或缩放窗口。无论是否显示，⌘W 都会关闭当前选中窗口。"
+          }
+        }
+      }
+    },
+    "Show hint strip": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show hint strip"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示快捷提示条"
+          }
+        }
+      }
+    },
+    "Keyboard shortcut hints at the bottom of the picker.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard shortcut hints at the bottom of the picker."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在选择器底部显示键盘快捷提示。"
+          }
+        }
+      }
+    },
+    "Show window title first": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show window title first"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "窗口标题在前"
+          }
+        }
+      }
+    },
+    "Put the window title ahead of the app name in each tile and row.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Put the window title ahead of the app name in each tile and row."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在每个磁贴和列表行中，窗口标题显示在应用名之前。"
+          }
+        }
+      }
+    },
+    "Vertical mode": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vertical mode"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "纵向模式"
+          }
+        }
+      }
+    },
+    "Vertical list": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vertical list"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "纵向列表"
+          }
+        }
+      }
+    },
+    "One window per row instead of a grid.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One window per row instead of a grid."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每行一个窗口，而不是网格。"
+          }
+        }
+      }
+    },
+    "Show top header": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show top header"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示顶部栏"
+          }
+        }
+      }
+    },
+    "Filter text and window count at the top of the picker.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter text and window count at the top of the picker."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在选择器顶部显示过滤文本和窗口数量。"
+          }
+        }
+      }
+    },
+    "Show preview": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show preview"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示预览"
+          }
+        }
+      }
+    },
+    "Window thumbnail at the trailing edge of each row.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Window thumbnail at the trailing edge of each row."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在每行末尾显示窗口缩略图。"
+          }
+        }
+      }
+    },
+    "Show stoplights": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show stoplights"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示红绿灯"
+          }
+        }
+      }
+    },
+    "Close/minimize/zoom buttons inside each row.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close/minimize/zoom buttons inside each row."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在每行内显示关闭/最小化/缩放按钮。"
+          }
+        }
+      }
+    },
+    "Sizing": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sizing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尺寸"
+          }
+        }
+      }
+    },
+    "Columns": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Columns"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "列数"
+          }
+        }
+      }
+    },
+    "Number of columns in the grid view. %lld": {
+      "comment": "Settings row detail with column count",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Number of columns in the grid view. %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网格视图的列数。%lld"
+          }
+        }
+      }
+    },
+    "Thumbnail size": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thumbnail size"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缩略图大小"
+          }
+        }
+      }
+    },
+    "Overall picker size. %lldpt": {
+      "comment": "Settings row detail with point size",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overall picker size. %lldpt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择器整体大小。%lldpt"
+          }
+        }
+      }
+    },
+    "App icon size": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App icon size"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用图标大小"
+          }
+        }
+      }
+    },
+    "Size of the app icon on each tile and list row. %lldpt": {
+      "comment": "Settings row detail with point size",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Size of the app icon on each tile and list row. %lldpt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每个磁贴和列表行上的应用图标大小。%lldpt"
+          }
+        }
+      }
+    },
+    "Reset sizing": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset sizing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还原尺寸"
+          }
+        }
+      }
+    },
+    "Restore columns, thumbnail size, and app icon size.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore columns, thumbnail size, and app icon size."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "还原列数、缩略图大小和应用图标大小。"
+          }
+        }
+      }
+    },
+    "Advanced": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advanced"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高级"
+          }
+        }
+      }
+    },
+    "Picker activation delay": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Picker activation delay"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择器出现延迟"
+          }
+        }
+      }
+    },
+    "Hold the hotkey this long before the picker appears. A quick tap switches to your previous window without showing it. %lldms": {
+      "comment": "Settings row detail with milliseconds",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hold the hotkey this long before the picker appears. A quick tap switches to your previous window without showing it. %lldms"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按住快捷键这么久后才出现选择器。轻点则直接切到上一个窗口。%lldms"
+          }
+        }
+      }
+    },
+    "Reverse with Shift tap": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reverse with Shift tap"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点按 Shift 反向"
+          }
+        }
+      }
+    },
+    "While holding the hotkey, tap Shift to step backward. ⇧-Tab still works too.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "While holding the hotkey, tap Shift to step backward. ⇧-Tab still works too."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按住快捷键时点按 Shift 可反向步进。⇧-Tab 仍然可用。"
+          }
+        }
+      }
+    },
+    "Cross-Space": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cross-Space"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跨空间"
+          }
+        }
+      }
+    },
+    "Show cross-Space windows": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show cross-Space windows"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示其他空间的窗口"
+          }
+        }
+      }
+    },
+    "Include windows on other Spaces. Picking one moves it to your current Space.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include windows on other Spaces. Picking one moves it to your current Space."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "包含其他空间上的窗口。选中后会移到当前空间。"
+          }
+        }
+      }
+    },
+    "Mix by recent use": {
+      "comment": "Settings row",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mix by recent use"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按最近使用混合"
+          }
+        }
+      }
+    },
+    "Sort all windows together by recency instead of grouping by Space.": {
+      "comment": "Settings row detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort all windows together by recency instead of grouping by Space."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按最近使用把所有窗口排在一起，不按空间分组。"
+          }
+        }
+      }
+    },
+    "Drag to reorder. Unranked apps fall to the bottom alphabetically.": {
+      "comment": "Static order hint",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drag to reorder. Unranked apps fall to the bottom alphabetically."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖动以调整顺序。未排序的应用按字母排在底部。"
+          }
+        }
+      }
+    },
+    "No windows open right now.": {
+      "comment": "Empty static-order list",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No windows open right now."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前没有打开的窗口。"
+          }
+        }
+      }
+    },
+    "Excluded apps": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluded apps"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排除的应用"
+          }
+        }
+      }
+    },
+    "Windows from these apps won't appear in the picker.": {
+      "comment": "Excluded apps hint",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows from these apps won't appear in the picker."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这些应用的窗口不会出现在选择器中。"
+          }
+        }
+      }
+    },
+    "Nothing excluded.": {
+      "comment": "Empty blacklist",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing excluded."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未排除任何应用。"
+          }
+        }
+      }
+    },
+    "+ Add app": {
+      "comment": "Add excluded app",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+ Add app"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+ 添加应用"
+          }
+        }
+      }
+    },
+    "Accent": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accent"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "强调色"
+          }
+        }
+      }
+    },
+    "Accent shows up in the selection highlight and across this Settings window.": {
+      "comment": "Accent help",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accent shows up in the selection highlight and across this Settings window."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "强调色用于选中高亮和本设置窗口。"
+          }
+        }
+      }
+    },
+    "Background": {
+      "comment": "Settings section",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背景"
+          }
+        }
+      }
+    },
+    "How much the desktop blurs through the picker background.": {
+      "comment": "Blur help",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How much the desktop blurs through the picker background."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "桌面透过选择器背景的模糊程度。"
+          }
+        }
+      }
+    },
+    "System": {
+      "comment": "Accent name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统"
+          }
+        }
+      }
+    },
+    "Rose": {
+      "comment": "Accent name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rose"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "玫瑰"
+          }
+        }
+      }
+    },
+    "Blue": {
+      "comment": "Accent name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "蓝色"
+          }
+        }
+      }
+    },
+    "Mint": {
+      "comment": "Accent name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mint"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "薄荷"
+          }
+        }
+      }
+    },
+    "Peach": {
+      "comment": "Accent name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peach"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "蜜桃"
+          }
+        }
+      }
+    },
+    "Lavender": {
+      "comment": "Accent name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lavender"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "薰衣草"
+          }
+        }
+      }
+    },
+    "Mono": {
+      "comment": "Accent name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mono"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "单色"
+          }
+        }
+      }
+    },
+    "Light": {
+      "comment": "Blur level",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "轻"
+          }
+        }
+      }
+    },
+    "Medium": {
+      "comment": "Blur level",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medium"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
+          }
+        }
+      }
+    },
+    "Heavy": {
+      "comment": "Blur level",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heavy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重"
+          }
+        }
+      }
+    },
+    "Switch needs Accessibility for the ⌘-Tab hotkey. Screen Recording is only needed when thumbnails are enabled.": {
+      "comment": "Permissions intro",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch needs Accessibility for the ⌘-Tab hotkey. Screen Recording is only needed when thumbnails are enabled."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch 需要辅助功能权限才能使用 ⌘-Tab。仅在启用缩略图时才需要屏幕录制。"
+          }
+        }
+      }
+    },
+    "Accessibility": {
+      "comment": "Permission name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accessibility"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助功能"
+          }
+        }
+      }
+    },
+    "Intercept ⌘-Tab and ⌥-` system-wide.": {
+      "comment": "Settings Accessibility detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intercept ⌘-Tab and ⌥-` system-wide."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在全系统拦截 ⌘-Tab 和 ⌥-`。"
+          }
+        }
+      }
+    },
+    "Screen Recording": {
+      "comment": "Permission name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screen Recording"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "屏幕录制"
+          }
+        }
+      }
+    },
+    "Capture live thumbnails of every window.": {
+      "comment": "Settings Screen Recording detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture live thumbnails of every window."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕获每个窗口的实时缩略图。"
+          }
+        }
+      }
+    },
+    "Optional while thumbnails are disabled.": {
+      "comment": "Settings Screen Recording detail when optional",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional while thumbnails are disabled."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭缩略图时可选。"
+          }
+        }
+      }
+    },
+    "Open in System Settings": {
+      "comment": "Permission button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in System Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在系统设置中打开"
+          }
+        }
+      }
+    },
+    "Granted": {
+      "comment": "Permission granted",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Granted"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已授予"
+          }
+        }
+      }
+    },
+    "%lld spaces": {
+      "comment": "Picker header Space count",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld space"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld spaces"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个空间"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "No windows": {
+      "comment": "Empty picker",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No windows"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有窗口"
+          }
+        }
+      }
+    },
+    "No matches": {
+      "comment": "Empty picker after filter",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matches"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无匹配"
+          }
+        }
+      }
+    },
+    "MINIMIZED": {
+      "comment": "Picker badge",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MINIMIZED"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已最小化"
+          }
+        }
+      }
+    },
+    "HIDDEN": {
+      "comment": "Picker badge",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HIDDEN"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已隐藏"
+          }
+        }
+      }
+    },
+    "NO WINDOWS": {
+      "comment": "Picker badge",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NO WINDOWS"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无窗口"
+          }
+        }
+      }
+    },
+    "OTHER SPACE": {
+      "comment": "Picker badge",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OTHER SPACE"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其他空间"
+          }
+        }
+      }
+    },
+    "CURRENT": {
+      "comment": "Picker badge for the active Space",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CURRENT"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前"
+          }
+        }
+      }
+    },
+    "switch space": {
+      "comment": "Hint strip",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "switch space"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换空间"
+          }
+        }
+      }
+    },
+    "switch": {
+      "comment": "Hint strip",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "switch"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换"
+          }
+        }
+      }
+    },
+    "navigate": {
+      "comment": "Hint strip",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "navigate"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览"
+          }
+        }
+      }
+    },
+    "reverse": {
+      "comment": "Hint strip",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "reverse"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "反向"
+          }
+        }
+      }
+    },
+    "close": {
+      "comment": "Hint strip",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "close"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
+          }
+        }
+      }
+    },
+    "filter": {
+      "comment": "Hint strip",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "filter"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "过滤"
+          }
+        }
+      }
+    },
+    "cancel": {
+      "comment": "Hint strip",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cancel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        }
+      }
+    },
+    "About Switch": {
+      "comment": "About window and menu",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About Switch"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于 Switch"
+          }
+        }
+      }
+    },
+    "Settings…": {
+      "comment": "Status menu item",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置…"
+          }
+        }
+      }
+    },
+    "Switch Settings": {
+      "comment": "Settings window title",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch 设置"
+          }
+        }
+      }
+    },
+    "Version %@": {
+      "comment": "About window version line",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %@"
+          }
+        }
+      }
+    },
+    "Keyboard-driven window switcher for macOS.": {
+      "comment": "About window tagline",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard-driven window switcher for macOS."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "面向 macOS 的键盘窗口切换器。"
+          }
+        }
+      }
+    },
+    "Website": {
+      "comment": "About link",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网站"
+          }
+        }
+      }
+    },
+    "Source": {
+      "comment": "About link",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "源码"
+          }
+        }
+      }
+    },
+    "☕ Coffee": {
+      "comment": "About link",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "☕ Coffee"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "☕ 请杯咖啡"
+          }
+        }
+      }
+    },
+    "Check for Updates": {
+      "comment": "About window update button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
+          }
+        }
+      }
+    },
+    "© 2026 Sanyam Garg": {
+      "comment": "About window copyright",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "© 2026 Sanyam Garg"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "© 2026 Sanyam Garg"
+          }
+        }
+      }
+    },
+    "Two permissions before you can switch windows.": {
+      "comment": "Onboarding subtitle when thumbnails need Screen Recording",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Two permissions before you can switch windows."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换窗口前需要两项权限。"
+          }
+        }
+      }
+    },
+    "One permission before you can switch windows.": {
+      "comment": "Onboarding subtitle when only Accessibility is required",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One permission before you can switch windows."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换窗口前需要一项权限。"
+          }
+        }
+      }
+    },
+    "Lets Switch intercept ⌘-Tab and ⌥-`.": {
+      "comment": "Onboarding Accessibility detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lets Switch intercept ⌘-Tab and ⌥-`."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许 Switch 拦截 ⌘-Tab 和 ⌥-`。"
+          }
+        }
+      }
+    },
+    "Captures live thumbnails of your windows.": {
+      "comment": "Onboarding Screen Recording detail",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Captures live thumbnails of your windows."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕获窗口的实时缩略图。"
+          }
+        }
+      }
+    },
+    "Ready. Hold ⌘-Tab to switch windows.": {
+      "comment": "Onboarding ready label",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready. Hold ⌘-Tab to switch windows."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已就绪。按住 ⌘-Tab 即可切换窗口。"
+          }
+        }
+      }
+    },
+    "Click Open Settings, then toggle Switch on. This window updates automatically.": {
+      "comment": "Onboarding waiting hint",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Click Open Settings, then toggle Switch on. This window updates automatically."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点按“打开设置”，然后打开 Switch 开关。本窗口会自动更新。"
+          }
+        }
+      }
+    },
+    "Continue without thumbnails": {
+      "comment": "Onboarding skip thumbnails",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue without thumbnails"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不使用缩略图并继续"
+          }
+        }
+      }
+    },
+    "Open Settings": {
+      "comment": "Onboarding permission button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置"
+          }
+        }
+      }
+    },
+    "Updates not configured": {
+      "comment": "Alert when Sparkle is missing",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates not configured"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未配置更新"
+          }
+        }
+      }
+    },
+    "This build doesn't include Sparkle. Visit switch-dev.sanyamgarg.com to download the latest.": {
+      "comment": "Alert body when Sparkle is missing",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This build doesn't include Sparkle. Visit switch-dev.sanyamgarg.com to download the latest."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此构建未包含 Sparkle。请前往 switch-dev.sanyamgarg.com 下载最新版。"
+          }
+        }
+      }
+    },
+    "Desktop %lld": {
+      "comment": "Mission Control Space name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desktop %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "桌面 %lld"
+          }
+        }
+      }
+    },
+    "Desktop": {
+      "comment": "Fallback Space name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desktop"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "桌面"
+          }
+        }
+      }
+    },
+    "Fullscreen": {
+      "comment": "Fullscreen Space name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fullscreen"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全屏"
+          }
+        }
+      }
+    },
+    "%lld windows": {
+      "comment": "Space tile: window count",
+      "localizations": {
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld window"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld windows"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个窗口"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Tab": {
+      "comment": "Key name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tab"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tab"
+          }
+        }
+      }
+    },
+    "Space": {
+      "comment": "Key name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Space"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空格"
+          }
+        }
+      }
+    },
+    "Esc": {
+      "comment": "Key name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esc"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esc"
+          }
+        }
+      }
+    },
+    "Return": {
+      "comment": "Key name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Return"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Return"
+          }
+        }
+      }
+    },
+    "Enter": {
+      "comment": "Key name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter"
+          }
+        }
+      }
+    },
+    "Delete": {
+      "comment": "Key name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        }
+      }
+    },
+    "Fwd Del": {
+      "comment": "Forward delete key name",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fwd Del"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fwd Del"
+          }
+        }
+      }
+    },
+    "Key %lld": {
+      "comment": "Unknown key code fallback",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "键 %lld"
+          }
+        }
+      }
+    },
+    "Needs at least one modifier (⌘, ⌥, or ⌃).": {
+      "comment": "Hotkey rejected: no modifier",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Needs at least one modifier (⌘, ⌥, or ⌃)."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "至少需要一个修饰键（⌘、⌥ 或 ⌃）。"
+          }
+        }
+      }
+    },
+    "That combo is reserved by macOS or common apps.": {
+      "comment": "Hotkey rejected: reserved combo",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "That combo is reserved by macOS or common apps."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该组合已被 macOS 或常用应用保留。"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -107,13 +107,13 @@ final class SettingsModel: ObservableObject {
 private enum SettingsTab: String, CaseIterable, Identifiable {
     case general, picker, permissions, appearance, about
     var id: String { rawValue }
-    var label: String {
+    var label: LocalizedStringResource {
         switch self {
-        case .general: return "General"
-        case .picker: return "Picker"
-        case .permissions: return "Permissions"
-        case .appearance: return "Appearance"
-        case .about: return "About"
+        case .general: "General"
+        case .picker: "Picker"
+        case .permissions: "Permissions"
+        case .appearance: "Appearance"
+        case .about: "About"
         }
     }
 }
@@ -174,6 +174,14 @@ struct SettingsView: View {
     private var generalTab: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 26) {
+                section("Language") {
+                    row(title: "Language",
+                        detail: "Follows System Settings. Restart Switch after changing.") {
+                        Button("Open System Settings") { openLanguageSettings() }
+                            .controlSize(.small)
+                    }
+                }
+
                 section("Startup") {
                     row(title: "Launch Switch at login",
                         detail: "Run automatically when you sign in to your Mac.") {
@@ -209,7 +217,7 @@ struct SettingsView: View {
                                 .foregroundStyle(.red)
                         }
                         HStack {
-                            Text("Sticky: ⌘W/Q/H · Hold: ⇧⌘W/Q/H · ⇧ reverse")
+                            Text("Sticky: ⌘W/Q/H · Hold: ⇧⌘W/Q/H · ⇧ reverse", comment: "Hotkey help; keep glyphs")
                                 .font(.system(size: 11))
                                 .foregroundStyle(.secondary)
                             Spacer()
@@ -521,7 +529,7 @@ struct SettingsView: View {
                 initialBinding: model.stickyToggle ?? HotkeyBinding(keyCode: 0, modifiersRaw: 0),
                 onCapture: { b in applyHotkey(b, replacing: model.stickyToggle) { model.updateStickyToggle($0) } },
                 accent: prefs.accent.color,
-                placeholder: "Not set"
+                placeholder: String(localized: "Not set", comment: "Empty hotkey placeholder")
             )
             .frame(width: 180, height: 28)
             if model.stickyToggle != nil {
@@ -535,11 +543,11 @@ struct SettingsView: View {
     private var appOrderList: some View {
         let apps = orderedPickerApps()
         return VStack(alignment: .leading, spacing: 6) {
-            Text("Drag to reorder. Unranked apps fall to the bottom alphabetically.")
+            Text("Drag to reorder. Unranked apps fall to the bottom alphabetically.", comment: "Static order hint")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
             if apps.isEmpty {
-                Text("No windows open right now.")
+                Text("No windows open right now.", comment: "Empty static-order list")
                     .font(.system(size: 11))
                     .foregroundStyle(.tertiary)
             } else {
@@ -601,11 +609,11 @@ struct SettingsView: View {
     private var blacklistSection: some View {
         section("Excluded apps") {
             VStack(alignment: .leading, spacing: 10) {
-                Text("Windows from these apps won't appear in the picker.")
+                Text("Windows from these apps won't appear in the picker.", comment: "Excluded apps hint")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                 if prefs.blacklist.isEmpty {
-                    Text("Nothing excluded.")
+                    Text("Nothing excluded.", comment: "Empty blacklist")
                         .font(.system(size: 11))
                         .foregroundStyle(.tertiary)
                         .padding(.vertical, 4)
@@ -630,7 +638,7 @@ struct SettingsView: View {
                         }
                     }
                 } label: {
-                    Text("+ Add app")
+                    Text("+ Add app", comment: "Add excluded app")
                         .font(.system(size: 11, weight: .medium))
                 }
                 .menuStyle(.borderlessButton)
@@ -709,7 +717,7 @@ struct SettingsView: View {
                         Text(prefs.accent.label)
                             .font(.system(size: 11, weight: .medium))
                             .foregroundStyle(.secondary)
-                        Text("Accent shows up in the selection highlight and across this Settings window.")
+                        Text("Accent shows up in the selection highlight and across this Settings window.", comment: "Accent help")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)
                     }
@@ -727,7 +735,7 @@ struct SettingsView: View {
                         .pickerStyle(.segmented)
                         .labelsHidden()
                         blurPreview
-                        Text("How much the desktop blurs through the picker background.")
+                        Text("How much the desktop blurs through the picker background.", comment: "Blur help")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)
                     }
@@ -755,22 +763,29 @@ struct SettingsView: View {
             )
     }
 
-    private func section<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
+    private func openLanguageSettings() {
+        let url = URL(string: "x-apple.systempreferences:com.apple.Localization-Settings")!
+        if NSWorkspace.shared.open(url) { return }
+        NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Applications/System Settings.app"))
+    }
+
+    private func section<Content: View>(_ title: LocalizedStringResource, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 8) {
                 Circle()
                     .fill(prefs.accent.color)
                     .frame(width: 5, height: 5)
-                Text(title.uppercased())
+                Text(title)
                     .font(.system(size: 10, weight: .semibold, design: .monospaced))
                     .tracking(1.4)
                     .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
             }
             content()
         }
     }
 
-    private func row<Trailing: View>(title: String, detail: String, @ViewBuilder trailing: () -> Trailing) -> some View {
+    private func row<Trailing: View>(title: LocalizedStringResource, detail: LocalizedStringResource, @ViewBuilder trailing: () -> Trailing) -> some View {
         HStack(alignment: .center, spacing: 14) {
             VStack(alignment: .leading, spacing: 3) {
                 Text(title).font(.system(size: 13, weight: .medium))
@@ -786,7 +801,7 @@ struct SettingsView: View {
         .background(rowBackground)
     }
 
-    private func hotkeyRow(label: String, binding: HotkeyBinding?, alternate: HotkeyBinding?, detail: String? = nil,
+    private func hotkeyRow(label: LocalizedStringResource, binding: HotkeyBinding?, alternate: HotkeyBinding?, detail: LocalizedStringResource? = nil,
                            onCapture: @escaping (HotkeyBinding?) -> Void,
                            onAlternateCapture: @escaping (HotkeyBinding?) -> Void) -> some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -795,8 +810,8 @@ struct SettingsView: View {
                     .font(.system(size: 13, weight: .medium))
                     .frame(width: 100, alignment: .leading)
                 VStack(alignment: .leading, spacing: 6) {
-                    hotkeyBindingRow(label: "Primary", binding: binding, onCapture: onCapture)
-                    hotkeyBindingRow(label: "Alternate", binding: alternate, onCapture: onAlternateCapture)
+                    hotkeyBindingRow(label: "Primary", binding: binding, clearHelp: "Clear primary shortcut", onCapture: onCapture)
+                    hotkeyBindingRow(label: "Alternate", binding: alternate, clearHelp: "Clear alternate shortcut", onCapture: onAlternateCapture)
                 }
                 Spacer()
             }
@@ -809,7 +824,7 @@ struct SettingsView: View {
         }
     }
 
-    private func hotkeyBindingRow(label: String, binding: HotkeyBinding?, onCapture: @escaping (HotkeyBinding?) -> Void) -> some View {
+    private func hotkeyBindingRow(label: LocalizedStringResource, binding: HotkeyBinding?, clearHelp: LocalizedStringResource, onCapture: @escaping (HotkeyBinding?) -> Void) -> some View {
         HStack(spacing: 8) {
             Text(label)
                 .font(.system(size: 11))
@@ -819,7 +834,7 @@ struct SettingsView: View {
                 initialBinding: binding ?? HotkeyBinding(keyCode: 0, modifiersRaw: 0),
                 onCapture: { onCapture($0) },
                 accent: prefs.accent.color,
-                placeholder: "Not set"
+                placeholder: String(localized: "Not set", comment: "Empty hotkey placeholder")
             )
             .frame(width: 150, height: 28)
             if binding != nil {
@@ -828,7 +843,7 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
-                .help("Clear \(label.lowercased()) shortcut")
+                .help(clearHelp)
             }
         }
         .frame(height: 28)
@@ -862,7 +877,7 @@ struct SettingsView: View {
         if let msg = HotkeyValidator.reject(keyCode: b.keyCode, flags: b.cgFlags) {
             rejectMessage = msg
         } else if configuredHotkeys.contains(where: { $0 != old && $0.conflicts(with: b) }) {
-            rejectMessage = "That shortcut is already assigned."
+            rejectMessage = String(localized: "That shortcut is already assigned.", comment: "Hotkey already in use")
         } else {
             rejectMessage = nil
             save(b)
@@ -885,7 +900,7 @@ struct PermissionsTabView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                Text("Switch needs Accessibility for the ⌘-Tab hotkey. Screen Recording is only needed when thumbnails are enabled.")
+                Text("Switch needs Accessibility for the ⌘-Tab hotkey. Screen Recording is only needed when thumbnails are enabled.", comment: "Permissions intro")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
 
@@ -897,7 +912,9 @@ struct PermissionsTabView: View {
                 )
                 permRow(
                     title: "Screen Recording",
-                    detail: SwitchPreferences.shared.showThumbnails ? "Capture live thumbnails of every window." : "Optional while thumbnails are disabled.",
+                    detail: SwitchPreferences.shared.showThumbnails
+                        ? LocalizedStringResource("Capture live thumbnails of every window.", comment: "Settings Screen Recording detail")
+                        : LocalizedStringResource("Optional while thumbnails are disabled.", comment: "Settings Screen Recording detail when optional"),
                     granted: perms.screenCapture,
                     action: { perms.openScreenCapture() }
                 )
@@ -908,7 +925,7 @@ struct PermissionsTabView: View {
         .onDisappear { perms.stopPolling() }
     }
 
-    private func permRow(title: String, detail: String, granted: Bool, action: @escaping () -> Void) -> some View {
+    private func permRow(title: LocalizedStringResource, detail: LocalizedStringResource, granted: Bool, action: @escaping () -> Void) -> some View {
         HStack(spacing: 14) {
             Image(systemName: granted ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
                 .font(.system(size: 18))
@@ -1089,7 +1106,7 @@ final class KeyRecorderNSView: NSView {
 
     private func redraw() {
         if recording {
-            label.stringValue = "Press a key…"
+            label.stringValue = String(localized: "Press a key…", comment: "Hotkey recorder prompt")
             label.textColor = .secondaryLabelColor
             layer?.borderColor = accentNSColor.cgColor
             layer?.backgroundColor = accentNSColor.withAlphaComponent(0.10).cgColor

--- a/Sources/Switch/SettingsWindow.swift
+++ b/Sources/Switch/SettingsWindow.swift
@@ -32,7 +32,7 @@ final class SettingsWindow {
             backing: .buffered,
             defer: false
         )
-        win.title = "Switch Settings"
+        win.title = String(localized: "Switch Settings", comment: "Settings window title")
         win.contentViewController = host
         win.center()
         win.isReleasedWhenClosed = false

--- a/Sources/Switch/StatusBarController.swift
+++ b/Sources/Switch/StatusBarController.swift
@@ -12,30 +12,30 @@ final class StatusBarController {
 
     private func configure(_ item: NSStatusItem) {
         if let button = item.button {
-            let img = NSImage(systemSymbolName: "square.on.square", accessibilityDescription: "Switch")
+            let img = NSImage(systemSymbolName: "square.on.square", accessibilityDescription: String(localized: "Switch", comment: "Brand name; do not translate"))
             img?.isTemplate = true
             button.image = img
         }
 
         let menu = NSMenu()
 
-        let header = NSMenuItem(title: "Switch", action: nil, keyEquivalent: "")
+        let header = NSMenuItem(title: String(localized: "Switch", comment: "Brand name; do not translate"), action: nil, keyEquivalent: "")
         header.isEnabled = false
         menu.addItem(header)
 
         menu.addItem(.separator())
 
-        let about = NSMenuItem(title: "About Switch", action: #selector(openAbout), keyEquivalent: "")
+        let about = NSMenuItem(title: String(localized: "About Switch", comment: "Status menu item"), action: #selector(openAbout), keyEquivalent: "")
         about.target = self
         menu.addItem(about)
 
-        let settings = NSMenuItem(title: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
+        let settings = NSMenuItem(title: String(localized: "Settings…", comment: "Status menu item"), action: #selector(openSettings), keyEquivalent: ",")
         settings.target = self
         menu.addItem(settings)
 
         menu.addItem(.separator())
 
-        let quit = NSMenuItem(title: "Quit Switch", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        let quit = NSMenuItem(title: String(localized: "Quit Switch", comment: "Status menu item"), action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
         quit.target = NSApp
         menu.addItem(quit)
 

--- a/Sources/Switch/SwitchPreferences.swift
+++ b/Sources/Switch/SwitchPreferences.swift
@@ -14,15 +14,15 @@ final class SwitchPreferences: ObservableObject {
     enum AccentChoice: String, CaseIterable, Identifiable {
         case system, rose, blue, mint, peach, lavender, monochrome
         var id: String { rawValue }
-        var label: String {
+        var label: LocalizedStringResource {
             switch self {
-            case .system: return "System"
-            case .rose: return "Rose"
-            case .blue: return "Blue"
-            case .mint: return "Mint"
-            case .peach: return "Peach"
-            case .lavender: return "Lavender"
-            case .monochrome: return "Mono"
+            case .system: "System"
+            case .rose: "Rose"
+            case .blue: "Blue"
+            case .mint: "Mint"
+            case .peach: "Peach"
+            case .lavender: "Lavender"
+            case .monochrome: "Mono"
             }
         }
         var color: Color {
@@ -41,11 +41,11 @@ final class SwitchPreferences: ObservableObject {
     enum BackgroundBlur: String, CaseIterable, Identifiable {
         case light, medium, heavy
         var id: String { rawValue }
-        var label: String {
+        var label: LocalizedStringResource {
             switch self {
-            case .light: return "Light"
-            case .medium: return "Medium"
-            case .heavy: return "Heavy"
+            case .light: "Light"
+            case .medium: "Medium"
+            case .heavy: "Heavy"
             }
         }
         var material: Material {

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -78,10 +78,10 @@ struct SwitchView: View {
     }
 
     private func windowBadgeText(for window: WindowInfo) -> String {
-        if window.isMinimized { return "MINIMIZED" }
-        if window.isHidden { return "HIDDEN" }
-        if window.isWindowless { return "NO WINDOWS" }
-        return window.spaceLabel?.uppercased() ?? "OTHER SPACE"
+        if window.isMinimized { return String(localized: "MINIMIZED", comment: "Picker badge") }
+        if window.isHidden { return String(localized: "HIDDEN", comment: "Picker badge") }
+        if window.isWindowless { return String(localized: "NO WINDOWS", comment: "Picker badge") }
+        return window.spaceLabel ?? String(localized: "OTHER SPACE", comment: "Picker badge")
     }
 
     private var showHeader: Bool {
@@ -152,10 +152,16 @@ struct SwitchView: View {
             }
             Spacer()
             if !model.filteredWindows.isEmpty {
-                Text(isSpaceMode ? "\(model.filteredWindows.count) spaces" : "\(model.filteredWindows.count)")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.tertiary)
-                    .monospacedDigit()
+                Group {
+                    if isSpaceMode {
+                        Text("\(model.filteredWindows.count) spaces", comment: "Picker header Space count")
+                    } else {
+                        Text(verbatim: "\(model.filteredWindows.count)")
+                    }
+                }
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.tertiary)
+                .monospacedDigit()
             }
         }
         .padding(.horizontal, 22)
@@ -216,9 +222,15 @@ struct SwitchView: View {
             Image(systemName: model.filterText.isEmpty ? "rectangle.stack" : "magnifyingglass")
                 .font(.system(size: 20, weight: .medium))
                 .foregroundStyle(.tertiary)
-            Text(model.filterText.isEmpty ? "No windows" : "No matches")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.secondary)
+            if model.filterText.isEmpty {
+                Text("No windows", comment: "Empty picker")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("No matches", comment: "Empty picker after filter")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
         }
         .transition(.scale(scale: 0.98).combined(with: .opacity))
     }
@@ -296,9 +308,9 @@ struct SwitchView: View {
         .buttonStyle(.plain)
     }
 
-    private func hint(_ key: String, _ label: String) -> some View {
+    private func hint(_ key: String, _ label: LocalizedStringResource) -> some View {
         HStack(spacing: 5) {
-            Text(key)
+            Text(verbatim: key)
                 .font(.system(size: 10, weight: .semibold, design: .monospaced))
                 .tracking(1)
                 .foregroundStyle(.primary.opacity(0.85))
@@ -449,7 +461,7 @@ struct SwitchView: View {
             }
             if isSpaceMode {
                 if window.spaceLabel == "Current" {
-                    capsuleBadge("CURRENT")
+                    capsuleBadge(String(localized: "CURRENT", comment: "Picker badge for the active Space"))
                 }
             } else {
                 windowBadge(for: window)

--- a/Sources/Switch/WindowEnumerator.swift
+++ b/Sources/Switch/WindowEnumerator.swift
@@ -287,13 +287,13 @@ enum WindowEnumerator {
             let sorted = WindowMRU.sorted(windows, frontmost: nil)
             guard let target = sorted.first else { return nil }
             let apps = Array(NSOrderedSet(array: sorted.map(\.appName)).compactMap { $0 as? String }).prefix(3)
-            let suffix = sorted.count == 1 ? "1 window" : "\(sorted.count) windows"
+            let suffix = String(localized: "\(sorted.count) windows", comment: "Space tile: window count")
             let detail = apps.isEmpty ? suffix : "\(suffix) · \(apps.joined(separator: ", "))"
             let info = metadata.labels[sid]
             return WindowInfo(
                 id: target.id,
                 pid: target.pid,
-                appName: info?.label ?? "Desktop",
+                appName: info?.label ?? String(localized: "Desktop", comment: "Fallback Space name"),
                 title: detail,
                 bounds: target.bounds,
                 spaceID: sid,
@@ -326,9 +326,9 @@ enum WindowEnumerator {
                 let type = space["type"] as? Int ?? 0
                 if type == 0 {
                     desktop += 1
-                    labels[id] = ("Desktop \(desktop)", false)
+                    labels[id] = (String(localized: "Desktop \(desktop)", comment: "Mission Control Space name"), false)
                 } else {
-                    labels[id] = ("Fullscreen", true)
+                    labels[id] = (String(localized: "Fullscreen", comment: "Fullscreen Space name"), true)
                 }
             }
         }

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -1,0 +1,59 @@
+# Translating Switch
+
+Switch uses Apple String Catalogs. Language follows the macOS system language. There is no in-app language picker.
+
+Supported locales: `en` (source) and `zh-Hans` (Simplified Chinese). Other locales fall back to English.
+
+## Files
+
+- `Sources/Switch/Resources/Localizable.xcstrings` — UI, menus, alerts, Space names, key names
+- `Sources/Switch/Resources/InfoPlist.xcstrings` — `NSAppleEventsUsageDescription` and `NSScreenCaptureUsageDescription`
+- `Sources/Switch/Resources/<locale>.lproj/` — empty locale stubs so Xcode lists the language
+
+Do not add `Localizable.strings`. Edit the catalogs in Xcode (or the same JSON in a PR).
+
+## Adding a language
+
+1. In Xcode, open `Localizable.xcstrings` and add the locale.
+2. Do the same for `InfoPlist.xcstrings`.
+3. Add `Sources/Switch/Resources/<locale>.lproj/.gitkeep` (no `.strings` files).
+4. Translate in the catalog. Prefer a native-speaker PR that edits those two files only.
+
+After changing the system language, quit and reopen Switch.
+
+## Extraction
+
+`project.yml` sets `SWIFT_EMIT_LOC_STRINGS` and `STRING_CATALOG_GENERATE_SYMBOLS`. Rebuild after adding `Text("…", comment:)` or `String(localized:comment:)` so new keys land in the catalog.
+
+Interpolation keys must match Swift extraction:
+
+- `"\(count) spaces"` → `%lld spaces`
+- `"Desktop \(n)"` → `Desktop %lld`
+- `"\(count) windows"` → `%lld windows` (vary by plural)
+
+English plurals use `one` / `other`. Simplified Chinese uses only `other`.
+
+## Do not translate
+
+- Brand **Switch** (`shouldTranslate: false`)
+- Window titles from apps, `app.localizedName`, filter text
+- Shortcut glyphs (`⌘W`, `↵`, `⇧`) and F1–F12 / arrow symbols
+- UserDefaults keys, CGS keys such as `"Current Space"`, process skip lists
+- Internal sentinel `"Current"` (compared in code). Only the on-screen badge `CURRENT` is localized
+- README (English product docs stay English)
+
+## Glossary
+
+| Term | Keep / prefer |
+| --- | --- |
+| Switch | Brand. Never translate. |
+| Space | Mission Control Space. Do not replace with “desktop” unless the string is the generated name `Desktop %lld`. |
+| Desktop N | User-visible Space name for a desktop Space. |
+| Fullscreen | User-visible name for a fullscreen Space. |
+| picker | The Switch overlay that lists windows. |
+| sticky | Picker stays open after you release the modifier. Keep “sticky” if the language already uses it in this product sense; otherwise a short local equivalent is fine. |
+| Space (key) | Keyboard Space bar. This catalog key is the key name, not Mission Control. |
+
+## Info.plist
+
+English usage strings stay in `Info.plist`. Translations live only in `InfoPlist.xcstrings`.

--- a/project.yml
+++ b/project.yml
@@ -3,6 +3,7 @@ options:
   bundleIdPrefix: com.sanyamgarg
   deploymentTarget:
     macOS: "14.0"
+  developmentLanguage: en
   createIntermediateGroups: true
 settings:
   base:
@@ -37,6 +38,8 @@ targets:
         LD_RUNPATH_SEARCH_PATHS: "@executable_path/../Frameworks"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         SWIFT_OBJC_BRIDGING_HEADER: Sources/Switch/Switch-Bridging-Header.h
+        SWIFT_EMIT_LOC_STRINGS: YES
+        STRING_CATALOG_GENERATE_SYMBOLS: YES
       configs:
         Debug:
           PRODUCT_BUNDLE_IDENTIFIER: com.sanyamgarg.switch.debug


### PR DESCRIPTION
Closes #138.

## Summary

This scopes #139 down to a single locale as requested: Simplified Chinese (`zh-Hans`) only, alongside the English source. It keeps the Apple String Catalogs approach from #138 (no custom i18n layer) — `Localizable.xcstrings` and `InfoPlist.xcstrings` — with no `Localizable.strings` files and no in-app language picker.

- Locales: `en` (source) + `zh-Hans`
- Removed the other 8 locale stubs and their machine-translated catalog entries
- `String(localized:)` / SwiftUI `Text` literals with comments
- Language follows System Settings → General → Language & Region → Applications
- Brand name `Switch` stays untranslated; window titles, app names, and key glyphs unchanged

Related: #140 takes a `.strings` + helper approach. This PR keeps the String Catalogs approach described in #138.

## Change graph

```mermaid
flowchart LR
    UI["SwiftUI and AppKit strings"] --> Catalog["Localizable.xcstrings"]
    Plist["Info.plist usage strings"] --> InfoCatalog["InfoPlist.xcstrings"]
    Catalog --> Bundle["zh-Hans.lproj resources"]
    InfoCatalog --> Bundle
    System["macOS application language"] --> Bundle
```

## Test plan

- [x] `xcodegen generate`
- [x] Release build: `xcodebuild -project Switch.xcodeproj -scheme Switch -configuration Release -destination 'platform=macOS' CODE_SIGN_IDENTITY="-" CODE_SIGNING_ALLOWED=NO build`
- [x] Built bundle contains only `en.lproj` and `zh-Hans.lproj` with compiled `Localizable.strings`, `InfoPlist.strings`, and `Localizable.stringsdict`
- [x] `plutil` check of compiled `zh-Hans.lproj` resources shows Simplified Chinese values for usage strings, settings, picker, and menu-bar strings

This repo has no CI. A live menu-bar screenshot is not attached because this environment cannot drive the overlay UI without colliding with a running Switch instance.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Simplified Chinese support using Apple String Catalogs while retaining English as the source language.
- Localizes SwiftUI, AppKit, menu-bar, settings, onboarding, picker, hotkey, and permission text.
- Adds `Localizable.xcstrings` and `InfoPlist.xcstrings` with `zh-Hans` translations.
- Configures XcodeGen localization extraction and documents the translation workflow.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge, with no concrete localization, packaging, or runtime defects identified.

The localized call sites preserve dynamic content where required, interpolated lookup keys align with the catalog, privacy keys match Info.plist, and the catalogs are included through the application target’s source tree.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Sources/Switch/Resources/Localizable.xcstrings | Defines English source strings and Simplified Chinese translations, including matching interpolation and pluralization keys. |
| Sources/Switch/Resources/InfoPlist.xcstrings | Localizes the existing Accessibility and Screen Recording privacy declarations with keys aligned to Info.plist. |
| Sources/Switch/SettingsView.swift | Converts settings labels and helper APIs to localized resources and adds a link to macOS language settings. |
| Sources/Switch/SwitchView.swift | Localizes picker badges, empty states, counts, and hints while preserving runtime text and shortcut glyphs. |
| Sources/Switch/WindowEnumerator.swift | Localizes generated Space names and window-count details with catalog-compatible interpolation. |
| project.yml | Sets English as the development language and enables Swift localization extraction and catalog symbols. |
| TRANSLATION.md | Documents supported locales, catalog maintenance, interpolation keys, and content that must remain untranslated. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[SwiftUI and AppKit source strings] --> B[Localizable.xcstrings]
  C[Info.plist privacy descriptions] --> D[InfoPlist.xcstrings]
  B --> E[Xcode resource compilation]
  D --> E
  F[macOS application language] --> G{Selected locale}
  E --> G
  G -->|English| H[English UI and permission text]
  G -->|zh-Hans| I[Simplified Chinese UI and permission text]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Simplified Chinese localization with..."](https://github.com/sanyam-g/switch/commit/273f6da9b6754975c0a62b7c98817d61b3670c02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56129086)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Application packaging and entitlements](https://app.greptile.com/sanyamg/-/custom-context/knowledge-base/sanyam-g/switch/-/docs/application-packaging-and-entitlements.md)
- Knowledge Base — [Onboarding and accessibility permissions](https://app.greptile.com/sanyamg/-/custom-context/knowledge-base/sanyam-g/switch/-/docs/onboarding-and-accessibility-permissions.md)
- Knowledge Base — [Settings and preference storage](https://app.greptile.com/sanyamg/-/custom-context/knowledge-base/sanyam-g/switch/-/docs/settings-and-preference-storage.md)
- Knowledge Base — [App launch and status bar controls](https://app.greptile.com/sanyamg/-/custom-context/knowledge-base/sanyam-g/switch/-/docs/app-launch-and-status-bar.md)
- Knowledge Base — [Switcher model and presentation](https://app.greptile.com/sanyamg/-/custom-context/knowledge-base/sanyam-g/switch/-/docs/switcher-model-and-presentation.md)
</details>


<!-- /greptile_comment -->