### PR TITLE
Fix clipped picker rows, add a Rows setting, and a per-invocation ⌘F filter

### DIFF
--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -90,6 +90,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             window?.dismiss()
         }
         model.cancelAndDismiss = cancelAndDismiss
+        model.onMetricsChange = { [weak window] in window?.applyContentSize() }
         hotkey.onCloseSelected = { present(); model.closeSelected() }
         hotkey.onCloseSelectedApp = { present(); model.closeSelectedApp() }
         hotkey.onHideSelected = { present(); model.hideSelected() }
@@ -110,6 +111,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .sink { [weak window] _ in window?.applyContentSize() }
             .store(in: &cancellables)
         SwitchPreferences.shared.$thumbnailHeight
+            .dropFirst()
+            .sink { [weak window] _ in window?.applyContentSize() }
+            .store(in: &cancellables)
+        // List rows are sized from the icon, so the panel has to be remeasured with it.
+        SwitchPreferences.shared.$appIconSize
             .dropFirst()
             .sink { [weak window] _ in window?.applyContentSize() }
             .store(in: &cancellables)
@@ -371,6 +377,7 @@ final class SwitcherWindow: NSPanel {
         let fitted = SwitcherPanelSize.current(
             mode: model.mode,
             itemCount: model.filteredWindows.count,
+            metrics: model.metrics,
             screen: screen
         )
         model.panelSize = CGSize(width: fitted.width, height: fitted.height)
@@ -411,32 +418,77 @@ final class SwitcherWindow: NSPanel {
 }
 
 private enum SwitcherPanelSize {
-    static func current(mode: HotkeyManager.Mode, itemCount: Int, screen: NSScreen?) -> NSSize {
+    static func current(mode: HotkeyManager.Mode, itemCount: Int, metrics: PanelMetrics, screen: NSScreen?) -> NSSize {
         let defaults = UserDefaults.standard
         let isList = defaults.bool(forKey: SwitchPreferences.verticalListKey)
         let thumb = CGFloat((defaults.object(forKey: SwitchPreferences.thumbnailHeightKey) as? Double) ?? SwitchPreferences.defaultThumbnailHeight)
         let scale = thumb / CGFloat(SwitchPreferences.defaultThumbnailHeight)
         let count = max(itemCount, 1)
+        // Matches showHeader in SwitchView, minus the filter-text case: a filter both
+        // reveals the header and changes the count, and the panel is remeasured then.
+        let showsHeader = mode == .spaces || !isList
+            || ((defaults.object(forKey: SwitchPreferences.verticalShowHeaderKey) as? Bool) ?? true)
         // Every mode sizes to the window count; a fixed panel leaves rows of empty backdrop (#134).
         let size = (mode == .spaces || isList)
-            ? listSize(defaults: defaults, count: count, scale: scale)
-            : gridSize(defaults: defaults, count: count, thumb: thumb, scale: scale)
+            ? listSize(defaults: defaults, count: count, scale: scale, showsHeader: showsHeader, metrics: metrics)
+            : gridSize(defaults: defaults, count: count, thumb: thumb, scale: scale, metrics: metrics)
         return fit(size, on: screen)
     }
 
-    private static func listSize(defaults: UserDefaults, count: Int, scale: CGFloat) -> NSSize {
+    private static func lineHeight(_ font: NSFont) -> CGFloat {
+        ceil(font.ascender - font.descender + font.leading)
+    }
+
+    // Mirrors hintStrip in SwitchView: one line of pills plus .padding(.vertical, 8),
+    // where the key pill adds .padding(.vertical, 1) around its monospaced text.
+    private static let hintStripHeight: CGFloat = {
+        let label = lineHeight(.systemFont(ofSize: 11))
+        let key = lineHeight(.monospacedSystemFont(ofSize: 10, weight: .semibold)) + 2
+        return max(label, key) + 16
+    }()
+
+    // Mirrors listRow in SwitchView: the row is as tall as its tallest element plus
+    // .padding(.vertical, 6) on each side. A hardcoded height silently disagreed with
+    // non-default icon sizes and left a partial extra row visible.
+    private static let listRowTextHeight: CGFloat =
+        lineHeight(.systemFont(ofSize: 13, weight: .medium)) + 2 + lineHeight(.systemFont(ofSize: 11))
+    private static let listRowPreviewHeight: CGFloat = 50
+    private static let listRowVerticalPadding: CGFloat = 6
+
+    private static func listRowHeight(iconSize: CGFloat, showPreview: Bool) -> CGFloat {
+        var content = max(iconSize, listRowTextHeight)
+        if showPreview { content = max(content, listRowPreviewHeight) }
+        return content + listRowVerticalPadding * 2
+    }
+
+    /// A measurement of the real thing beats any constant that mirrors the view by hand.
+    private static func measured(_ value: CGFloat, fallback: CGFloat) -> CGFloat {
+        value > 0 ? value : fallback
+    }
+
+    private static func listSize(defaults: UserDefaults, count: Int, scale: CGFloat, showsHeader: Bool, metrics: PanelMetrics) -> NSSize {
         let showHints = (defaults.object(forKey: SwitchPreferences.showHintStripKey) as? Bool) ?? true
         let showThumbs = (defaults.object(forKey: SwitchPreferences.showThumbnailsKey) as? Bool) ?? true
         let showPreview = ((defaults.object(forKey: SwitchPreferences.verticalShowPreviewKey) as? Bool) ?? true) && showThumbs
-        let hintHeight: CGFloat = showHints ? 38 : 0
-        let rowHeight: CGFloat = showPreview ? 62 : 48
+        let iconSize = CGFloat((defaults.object(forKey: SwitchPreferences.appIconSizeKey) as? Double) ?? SwitchPreferences.defaultAppIconSize)
+        let hintHeight: CGFloat = showHints ? measured(metrics.hintHeight, fallback: hintStripHeight) : 0
+        let rowHeight = measured(
+            metrics.rowHeight,
+            fallback: listRowHeight(iconSize: iconSize, showPreview: showPreview)
+        )
         let visibleRows = min(count, 8)
         let rowGaps = CGFloat(max(visibleRows - 1, 0)) * 4
-        let height = 26 + CGFloat(visibleRows) * rowHeight + rowGaps + hintHeight + 20
+        let headerHeight: CGFloat = showsHeader ? measured(metrics.headerHeight, fallback: 26) : 0
+        let topPadding: CGFloat = showsHeader ? 10 : 14
+        // The top padding is inside the scroll content; the bottom one sits outside it,
+        // so both are always on screen and neither can be filled by a clipped row.
+        let bottomPadding: CGFloat = 10
+        let height = headerHeight + topPadding + CGFloat(visibleRows) * rowHeight
+            + rowGaps + bottomPadding + hintHeight
         return NSSize(width: 520 * scale, height: min(560 * scale, max(260, height)))
     }
 
-    private static func gridSize(defaults: UserDefaults, count: Int, thumb: CGFloat, scale: CGFloat) -> NSSize {
+    private static func gridSize(defaults: UserDefaults, count: Int, thumb: CGFloat, scale: CGFloat, metrics: PanelMetrics) -> NSSize {
         let showHints = (defaults.object(forKey: SwitchPreferences.showHintStripKey) as? Bool) ?? true
         let showThumbs = (defaults.object(forKey: SwitchPreferences.showThumbnailsKey) as? Bool) ?? true
         let tileThumb: CGFloat = showThumbs ? thumb : SwitchPreferences.compactThumbnailHeight
@@ -450,10 +502,10 @@ private enum SwitcherPanelSize {
         let width = horizontalPadding + CGFloat(columns) * columnWidth + CGFloat(max(columns - 1, 0)) * columnSpacing
 
         let rows = Int(ceil(Double(count) / Double(columns)))
-        let tileHeight = tileThumb + 52
+        let tileHeight = measured(metrics.tileHeight, fallback: tileThumb + 52)
         let rowsHeight = CGFloat(rows) * tileHeight + CGFloat(max(rows - 1, 0)) * 14
-        let hintHeight: CGFloat = showHints ? 38 : 0
-        let height = 26 + 16 + rowsHeight + hintHeight
+        let hintHeight: CGFloat = showHints ? measured(metrics.hintHeight, fallback: hintStripHeight) : 0
+        let height = measured(metrics.headerHeight, fallback: 26) + 16 + rowsHeight + hintHeight
         return NSSize(width: max(560, width), height: min(560 * scale, max(320, height)))
     }
 

--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -342,6 +342,8 @@ extension AppDelegate: SPUStandardUserDriverDelegate {
 
 final class SwitcherWindow: NSPanel {
     private let model: SwitchModel
+    /// Window count as of the last unfiltered layout, so a filter cannot resize the panel.
+    private var unfilteredCount = 0
 
     init(model: SwitchModel) {
         self.model = model
@@ -384,10 +386,13 @@ final class SwitcherWindow: NSPanel {
     }
 
     func applyContentSize(for screen: NSScreen? = nil) {
+        // Filtering must not resize the panel, so hold the count from before the filter
+        // was typed; a resize on every keystroke is more disruptive than empty backdrop.
+        if model.filterText.isEmpty { unfilteredCount = model.filteredWindows.count }
         // Row count is capped by the screen, so fall back to the one we are on.
         let fitted = SwitcherPanelSize.current(
             mode: model.mode,
-            itemCount: model.filteredWindows.count,
+            itemCount: unfilteredCount,
             metrics: model.metrics,
             screen: screen ?? self.screen ?? NSScreen.main
         )

--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -374,11 +374,12 @@ final class SwitcherWindow: NSPanel {
     }
 
     func applyContentSize(for screen: NSScreen? = nil) {
+        // Row count is capped by the screen, so fall back to the one we are on.
         let fitted = SwitcherPanelSize.current(
             mode: model.mode,
             itemCount: model.filteredWindows.count,
             metrics: model.metrics,
-            screen: screen
+            screen: screen ?? self.screen ?? NSScreen.main
         )
         model.panelSize = CGSize(width: fitted.width, height: fitted.height)
         setContentSize(fitted)
@@ -430,7 +431,8 @@ private enum SwitcherPanelSize {
             || ((defaults.object(forKey: SwitchPreferences.verticalShowHeaderKey) as? Bool) ?? true)
         // Every mode sizes to the window count; a fixed panel leaves rows of empty backdrop (#134).
         let size = (mode == .spaces || isList)
-            ? listSize(defaults: defaults, count: count, scale: scale, showsHeader: showsHeader, metrics: metrics)
+            ? listSize(defaults: defaults, count: count, scale: scale, showsHeader: showsHeader,
+                       metrics: metrics, screen: screen)
             : gridSize(defaults: defaults, count: count, thumb: thumb, scale: scale, metrics: metrics)
         return fit(size, on: screen)
     }
@@ -466,7 +468,12 @@ private enum SwitcherPanelSize {
         value > 0 ? value : fallback
     }
 
-    private static func listSize(defaults: UserDefaults, count: Int, scale: CGFloat, showsHeader: Bool, metrics: PanelMetrics) -> NSSize {
+    /// Upper bound on rows on screen at once; the screen can lower it further.
+    private static let maxListRows = 8
+    private static let listRowSpacing: CGFloat = 4
+
+    private static func listSize(defaults: UserDefaults, count: Int, scale: CGFloat, showsHeader: Bool,
+                                 metrics: PanelMetrics, screen: NSScreen?) -> NSSize {
         let showHints = (defaults.object(forKey: SwitchPreferences.showHintStripKey) as? Bool) ?? true
         let showThumbs = (defaults.object(forKey: SwitchPreferences.showThumbnailsKey) as? Bool) ?? true
         let showPreview = ((defaults.object(forKey: SwitchPreferences.verticalShowPreviewKey) as? Bool) ?? true) && showThumbs
@@ -476,16 +483,21 @@ private enum SwitcherPanelSize {
             metrics.rowHeight,
             fallback: listRowHeight(iconSize: iconSize, showPreview: showPreview)
         )
-        let visibleRows = min(count, 8)
-        let rowGaps = CGFloat(max(visibleRows - 1, 0)) * 4
         let headerHeight: CGFloat = showsHeader ? measured(metrics.headerHeight, fallback: 26) : 0
         let topPadding: CGFloat = showsHeader ? 10 : 14
         // The top padding is inside the scroll content; the bottom one sits outside it,
         // so both are always on screen and neither can be filled by a clipped row.
         let bottomPadding: CGFloat = 10
-        let height = headerHeight + topPadding + CGFloat(visibleRows) * rowHeight
-            + rowGaps + bottomPadding + hintHeight
-        return NSSize(width: 520 * scale, height: min(560 * scale, max(260, height)))
+        let chrome = headerHeight + topPadding + bottomPadding + hintHeight
+
+        // Whole rows only: a height the rows do not divide into leaves the remainder
+        // showing as a clipped row, which is what a fixed pixel cap used to produce.
+        let ceiling = (screen?.visibleFrame.height ?? .greatestFiniteMagnitude) * screenFraction
+        let fitting = Int(floor((ceiling - chrome + listRowSpacing) / (rowHeight + listRowSpacing)))
+        let visibleRows = max(1, min(count, maxListRows, fitting))
+        let rowGaps = CGFloat(max(visibleRows - 1, 0)) * listRowSpacing
+        let height = chrome + CGFloat(visibleRows) * rowHeight + rowGaps
+        return NSSize(width: 520 * scale, height: max(260, height))
     }
 
     private static func gridSize(defaults: UserDefaults, count: Int, thumb: CGFloat, scale: CGFloat, metrics: PanelMetrics) -> NSSize {
@@ -509,12 +521,14 @@ private enum SwitcherPanelSize {
         return NSSize(width: max(560, width), height: min(560 * scale, max(320, height)))
     }
 
+    private static let screenFraction: CGFloat = 0.92
+
     private static func fit(_ size: NSSize, on screen: NSScreen?) -> NSSize {
         guard let screen else { return size }
         let visible = screen.visibleFrame
         return NSSize(
-            width: min(size.width, visible.width * 0.92),
-            height: min(size.height, visible.height * 0.92)
+            width: min(size.width, visible.width * screenFraction),
+            height: min(size.height, visible.height * screenFraction)
         )
     }
 }

--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -119,6 +119,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .dropFirst()
             .sink { [weak window] _ in window?.applyContentSize() }
             .store(in: &cancellables)
+        SwitchPreferences.shared.$maxListRows
+            .dropFirst()
+            .sink { [weak window] _ in window?.applyContentSize() }
+            .store(in: &cancellables)
         SwitchPreferences.shared.$showThumbnails
             .dropFirst()
             .sink { [weak self, weak window] enabled in
@@ -468,8 +472,6 @@ private enum SwitcherPanelSize {
         value > 0 ? value : fallback
     }
 
-    /// Upper bound on rows on screen at once; the screen can lower it further.
-    private static let maxListRows = 8
     private static let listRowSpacing: CGFloat = 4
 
     private static func listSize(defaults: UserDefaults, count: Int, scale: CGFloat, showsHeader: Bool,
@@ -494,7 +496,9 @@ private enum SwitcherPanelSize {
         // showing as a clipped row, which is what a fixed pixel cap used to produce.
         let ceiling = (screen?.visibleFrame.height ?? .greatestFiniteMagnitude) * screenFraction
         let fitting = Int(floor((ceiling - chrome + listRowSpacing) / (rowHeight + listRowSpacing)))
-        let visibleRows = max(1, min(count, maxListRows, fitting))
+        let maxRows = (defaults.object(forKey: SwitchPreferences.maxListRowsKey) as? Int)
+            ?? SwitchPreferences.defaultMaxListRows
+        let visibleRows = max(1, min(count, maxRows, fitting))
         let rowGaps = CGFloat(max(visibleRows - 1, 0)) * listRowSpacing
         let height = chrome + CGFloat(visibleRows) * rowHeight + rowGaps
         return NSSize(width: 520 * scale, height: max(260, height))

--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -99,6 +99,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotkey.onPickSelectOnly = { present(); model.selectIndex($0) }
         hotkey.onFilterAppend = { present(); model.appendFilter($0) }
         hotkey.onFilterBackspace = { present(); model.backspaceFilter() }
+        hotkey.onFilterEnabled = {
+            model.filterSession = true
+            model.stickySession = true
+        }
         hotkey.onStickyToggle = {
             SwitchPreferences.shared.stickyMode.toggle()
         }

--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -99,9 +99,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotkey.onPickSelectOnly = { present(); model.selectIndex($0) }
         hotkey.onFilterAppend = { present(); model.appendFilter($0) }
         hotkey.onFilterBackspace = { present(); model.backspaceFilter() }
-        hotkey.onFilterEnabled = {
-            model.filterSession = true
-            model.stickySession = true
+        hotkey.onFilterSessionChanged = { enabled in
+            model.filterSession = enabled
+            // Stays sticky on the way out: the modifier is long released by now, and
+            // dropping sticky would arm the next release to commit.
+            if enabled { model.stickySession = true } else { model.clearFilter() }
         }
         hotkey.onStickyToggle = {
             SwitchPreferences.shared.stickyMode.toggle()

--- a/Sources/Switch/AppDelegate.swift
+++ b/Sources/Switch/AppDelegate.swift
@@ -101,9 +101,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotkey.onFilterBackspace = { present(); model.backspaceFilter() }
         hotkey.onFilterSessionChanged = { enabled in
             model.filterSession = enabled
+            if enabled { model.revealFilterHeader() }
             // Stays sticky on the way out: the modifier is long released by now, and
             // dropping sticky would arm the next release to commit.
-            if enabled { model.stickySession = true } else { model.clearFilter() }
+            if enabled {
+                model.stickySession = true
+            } else {
+                model.clearFilter()
+                model.hideFilterHeader()
+            }
         }
         hotkey.onStickyToggle = {
             SwitchPreferences.shared.stickyMode.toggle()
@@ -123,6 +129,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // List rows are sized from the icon, so the panel has to be remeasured with it.
         SwitchPreferences.shared.$appIconSize
             .dropFirst()
+            .sink { [weak window] _ in window?.applyContentSize() }
+            .store(in: &cancellables)
+        // The header appears with find mode even when the preference hides it, and the
+        // panel has to take that height or it comes out of the last row.
+        model.$filterHeaderVisible
+            .removeDuplicates()
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
             .sink { [weak window] _ in window?.applyContentSize() }
             .store(in: &cancellables)
         SwitchPreferences.shared.$maxListRows
@@ -394,6 +408,7 @@ final class SwitcherWindow: NSPanel {
             mode: model.mode,
             itemCount: unfilteredCount,
             metrics: model.metrics,
+            filterHeader: model.filterHeaderVisible,
             screen: screen ?? self.screen ?? NSScreen.main
         )
         model.panelSize = CGSize(width: fitted.width, height: fitted.height)
@@ -434,15 +449,16 @@ final class SwitcherWindow: NSPanel {
 }
 
 private enum SwitcherPanelSize {
-    static func current(mode: HotkeyManager.Mode, itemCount: Int, metrics: PanelMetrics, screen: NSScreen?) -> NSSize {
+    static func current(mode: HotkeyManager.Mode, itemCount: Int, metrics: PanelMetrics,
+                        filterHeader: Bool, screen: NSScreen?) -> NSSize {
         let defaults = UserDefaults.standard
         let isList = defaults.bool(forKey: SwitchPreferences.verticalListKey)
         let thumb = CGFloat((defaults.object(forKey: SwitchPreferences.thumbnailHeightKey) as? Double) ?? SwitchPreferences.defaultThumbnailHeight)
         let scale = thumb / CGFloat(SwitchPreferences.defaultThumbnailHeight)
         let count = max(itemCount, 1)
-        // Matches showHeader in SwitchView, minus the filter-text case: a filter both
-        // reveals the header and changes the count, and the panel is remeasured then.
-        let showsHeader = mode == .spaces || !isList
+        // Matches showHeader in SwitchView, filter-revealed header included: leaving it
+        // out cost the last row its space in exactly that configuration.
+        let showsHeader = mode == .spaces || !isList || filterHeader
             || ((defaults.object(forKey: SwitchPreferences.verticalShowHeaderKey) as? Bool) ?? true)
         // Every mode sizes to the window count; a fixed panel leaves rows of empty backdrop (#134).
         let size = (mode == .spaces || isList)

--- a/Sources/Switch/HotkeyManager.swift
+++ b/Sources/Switch/HotkeyManager.swift
@@ -40,6 +40,9 @@ final class HotkeyManager {
     var onFilterAppend: ((Character) -> Void)?
     var onFilterBackspace: (() -> Void)?
     var onStickyToggle: (() -> Void)?
+    /// Fired when ⌘F turns filtering on for an invocation that started without it.
+    /// The invocation also becomes sticky, so typing does not require holding the modifier.
+    var onFilterEnabled: (() -> Void)?
     var onOpenSettings: (() -> Void)?
 
     private let stateLock = NSLock()
@@ -48,6 +51,8 @@ final class HotkeyManager {
     private var armed: Mode?
     private var armedBinding: HotkeyBinding?
     private var armedSticky = false
+    /// Type-to-filter switched on by ⌘F for this invocation only.
+    private var armedFilter = false
     private var armedAt: Date?
     private var advanced = false
     private var lastShift = false
@@ -75,6 +80,7 @@ final class HotkeyManager {
     private static let kcW: CGKeyCode = 13
     private static let kcQ: CGKeyCode = 12
     private static let kcH: CGKeyCode = 4
+    private static let kcF: CGKeyCode = 3
     private static let kcComma: CGKeyCode = 43
     private static let kcDigits: [CGKeyCode] = [18, 19, 20, 21, 23, 22, 26, 28, 25]
     private static let kcKeypadDigits: [CGKeyCode] = [83, 84, 85, 86, 87, 88, 89, 91, 92]
@@ -272,10 +278,13 @@ final class HotkeyManager {
             let armedMode = armed
             let activeBinding = armedBinding
             let sticky = armedSticky
+            let filterSession = armedFilter
             stateLock.unlock()
 
             if armedMode != nil {
-                let typeToFilter = (UserDefaults.standard.object(forKey: SwitchPreferences.typeToFilterKey) as? Bool) ?? true
+                // ⌘F opts an invocation into filtering when the preference is off.
+                let typeToFilter = ((UserDefaults.standard.object(forKey: SwitchPreferences.typeToFilterKey) as? Bool) ?? true)
+                    || filterSession
                 let actionModifierMatches = cmd && (sticky || !typeToFilter || shift)
                 if kc == Self.kcEscape {
                     clearArmed()
@@ -313,6 +322,20 @@ final class HotkeyManager {
                 if actionModifierMatches && kc == Self.kcQ {
                     DispatchQueue.main.async { [weak self] in
                         self?.onCloseSelectedApp?()
+                    }
+                    return nil
+                }
+                if actionModifierMatches && kc == Self.kcF && !filterSession {
+                    stateLock.lock()
+                    armedFilter = true
+                    // Typing a filter one-handed means letting go of the modifier, so the
+                    // invocation goes sticky. advanced suppresses the quick-tap commit that
+                    // a release within stickyQuickTapMS of arming would otherwise trigger.
+                    armedSticky = true
+                    advanced = true
+                    stateLock.unlock()
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onFilterEnabled?()
                     }
                     return nil
                 }
@@ -407,6 +430,7 @@ final class HotkeyManager {
             armed = style.mode
             armedBinding = binding
             armedSticky = effective.sticky
+            armedFilter = false
             armedAt = Date()
             advanced = false
         } else {
@@ -428,6 +452,7 @@ final class HotkeyManager {
         armed = nil
         armedBinding = nil
         armedSticky = false
+        armedFilter = false
         armedAt = nil
         advanced = false
         shiftTapPending = false

--- a/Sources/Switch/HotkeyManager.swift
+++ b/Sources/Switch/HotkeyManager.swift
@@ -40,9 +40,10 @@ final class HotkeyManager {
     var onFilterAppend: ((Character) -> Void)?
     var onFilterBackspace: (() -> Void)?
     var onStickyToggle: (() -> Void)?
-    /// Fired when ⌘F turns filtering on for an invocation that started without it.
-    /// The invocation also becomes sticky, so typing does not require holding the modifier.
-    var onFilterEnabled: (() -> Void)?
+    /// Fired when ⌘F turns filtering on or off for an invocation that started without it.
+    /// Turning it on also makes the invocation sticky, so typing does not require
+    /// holding the modifier.
+    var onFilterSessionChanged: ((Bool) -> Void)?
     var onOpenSettings: (() -> Void)?
 
     private let stateLock = NSLock()
@@ -250,6 +251,7 @@ final class HotkeyManager {
 
         let flags = event.flags
         let cmd = flags.contains(.maskCommand)
+        let control = flags.contains(.maskControl)
         let shift = flags.contains(.maskShift)
         let kc = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
 
@@ -325,17 +327,20 @@ final class HotkeyManager {
                     }
                     return nil
                 }
-                if actionModifierMatches && kc == Self.kcF && !filterSession {
+                if actionModifierMatches && kc == Self.kcF {
+                    let enabling = !filterSession
                     stateLock.lock()
-                    armedFilter = true
-                    // Typing a filter one-handed means letting go of the modifier, so the
-                    // invocation goes sticky. advanced suppresses the quick-tap commit that
-                    // a release within stickyQuickTapMS of arming would otherwise trigger.
-                    armedSticky = true
-                    advanced = true
+                    armedFilter = enabling
+                    if enabling {
+                        // Typing a filter one-handed means letting go of the modifier, so the
+                        // invocation goes sticky. advanced suppresses the quick-tap commit that
+                        // a release within stickyQuickTapMS of arming would otherwise trigger.
+                        armedSticky = true
+                        advanced = true
+                    }
                     stateLock.unlock()
                     DispatchQueue.main.async { [weak self] in
-                        self?.onFilterEnabled?()
+                        self?.onFilterSessionChanged?(enabling)
                     }
                     return nil
                 }
@@ -367,10 +372,17 @@ final class HotkeyManager {
                     }
                     return nil
                 }
-                if typeToFilter, let c = filterChar(from: event) {
+                if typeToFilter, !cmd, !control, let c = filterChar(from: event) {
                     DispatchQueue.main.async { [weak self] in
                         self?.onFilterAppend?(c)
                     }
+                    return nil
+                }
+                // filterChar decodes with the modifiers stripped, so ⌘A would otherwise
+                // read as a plain "a" and be typed. Chords are not filter input; swallow
+                // the ones this picker does not act on rather than leak them to the app
+                // behind it.
+                if typeToFilter, cmd || control {
                     return nil
                 }
             }

--- a/Sources/Switch/SettingsView.swift
+++ b/Sources/Switch/SettingsView.swift
@@ -281,6 +281,16 @@ struct SettingsView: View {
                                 .tint(prefs.accent.color)
                         }
                         Divider().opacity(0.4)
+                        row(title: "Rows",
+                            detail: "Rows visible at once in the list view. \(prefs.maxListRows)") {
+                            Slider(value: Binding(
+                                get: { Double(prefs.maxListRows) },
+                                set: { prefs.maxListRows = Int($0.rounded()) }
+                            ), in: 4...20, step: 1)
+                                .frame(width: 140)
+                                .tint(prefs.accent.color)
+                        }
+                        Divider().opacity(0.4)
                         row(title: "Thumbnail size",
                             detail: "Overall picker size. \(Int(prefs.thumbnailHeight))pt") {
                             Slider(value: $prefs.thumbnailHeight, in: 80...300, step: 5)
@@ -296,7 +306,7 @@ struct SettingsView: View {
                         }
                         Divider().opacity(0.4)
                         row(title: "Reset sizing",
-                            detail: "Restore columns, thumbnail size, and app icon size.") {
+                            detail: "Restore columns, rows, thumbnail size, and app icon size.") {
                             Button("Reset") {
                                 resetSizing()
                             }
@@ -396,6 +406,7 @@ struct SettingsView: View {
 
     private func resetSizing() {
         prefs.gridColumns = SwitchPreferences.defaultGridColumns
+        prefs.maxListRows = SwitchPreferences.defaultMaxListRows
         prefs.thumbnailHeight = SwitchPreferences.defaultThumbnailHeight
         prefs.appIconSize = SwitchPreferences.defaultAppIconSize
     }

--- a/Sources/Switch/SwitchModel.swift
+++ b/Sources/Switch/SwitchModel.swift
@@ -28,6 +28,8 @@ final class SwitchModel: ObservableObject {
     @Published var panelSize = CGSize(width: 880, height: 560)
     /// Effective sticky for this invocation: global pref or a dedicated sticky binding (#131).
     @Published var stickySession = false
+    /// Type-to-filter turned on by ⌘F for this invocation, when the pref has it off.
+    @Published var filterSession = false
     private var currentSpaceOnly = false
     private var armReverse = false
 
@@ -93,6 +95,7 @@ final class SwitchModel: ObservableObject {
         let gen = armGeneration
         self.mode = style.mode
         stickySession = style.sticky
+        filterSession = false
         currentSpaceOnly = style.currentSpaceOnly
         armReverse = style.reverse
         quitPIDs.removeAll()

--- a/Sources/Switch/SwitchModel.swift
+++ b/Sources/Switch/SwitchModel.swift
@@ -40,6 +40,10 @@ final class SwitchModel: ObservableObject {
     @Published var stickySession = false
     /// Type-to-filter turned on by ⌘F for this invocation, when the pref has it off.
     @Published var filterSession = false
+    /// Set once find mode or a filter has revealed the header, and held for the rest of
+    /// the invocation. A header that comes and goes as the filter empties would resize
+    /// the panel under the user, and disagreeing with the sizing clips a row.
+    @Published private(set) var filterHeaderVisible = false
     private var currentSpaceOnly = false
     private var armReverse = false
 
@@ -108,6 +112,7 @@ final class SwitchModel: ObservableObject {
         self.mode = style.mode
         stickySession = style.sticky
         filterSession = false
+        filterHeaderVisible = false
         currentSpaceOnly = style.currentSpaceOnly
         armReverse = style.reverse
         quitPIDs.removeAll()
@@ -423,8 +428,20 @@ final class SwitchModel: ObservableObject {
         cancelAndDismiss?()
     }
 
+    func revealFilterHeader() {
+        filterHeaderVisible = true
+    }
+
+    /// Leaving find mode is a deliberate change, unlike a filter emptying as it is
+    /// edited, so the header goes away with it. A preference to always show the header
+    /// still wins: the view ORs this flag with it.
+    func hideFilterHeader() {
+        filterHeaderVisible = false
+    }
+
     func appendFilter(_ char: Character) {
         filterText.append(char)
+        filterHeaderVisible = true
         selected = 0
     }
 

--- a/Sources/Switch/SwitchModel.swift
+++ b/Sources/Switch/SwitchModel.swift
@@ -416,6 +416,12 @@ final class SwitchModel: ObservableObject {
         selected = 0
     }
 
+    func clearFilter() {
+        guard !filterText.isEmpty else { return }
+        filterText = ""
+        selected = 0
+    }
+
     func backspaceFilter() {
         guard !filterText.isEmpty else { return }
         filterText.removeLast()

--- a/Sources/Switch/SwitchModel.swift
+++ b/Sources/Switch/SwitchModel.swift
@@ -1,6 +1,22 @@
 import AppKit
 import SwiftUI
 
+/// Heights measured from the laid-out switcher, so the panel can be sized from what
+/// SwiftUI actually rendered instead of constants that mirror the view by hand.
+struct PanelMetrics: Equatable {
+    var rowHeight: CGFloat = 0
+    var tileHeight: CGFloat = 0
+    var hintHeight: CGFloat = 0
+    var headerHeight: CGFloat = 0
+
+    mutating func merge(_ other: PanelMetrics) {
+        rowHeight = max(rowHeight, other.rowHeight)
+        tileHeight = max(tileHeight, other.tileHeight)
+        hintHeight = max(hintHeight, other.hintHeight)
+        headerHeight = max(headerHeight, other.headerHeight)
+    }
+}
+
 @MainActor
 final class SwitchModel: ObservableObject {
     @Published var windows: [WindowInfo] = []
@@ -14,6 +30,18 @@ final class SwitchModel: ObservableObject {
     @Published var stickySession = false
     private var currentSpaceOnly = false
     private var armReverse = false
+
+    /// Deliberately not @Published: the view reports these during layout, and republishing
+    /// them from there would feed the next layout pass its own output.
+    private(set) var metrics = PanelMetrics()
+    /// Set by AppDelegate so a fresh measurement can resize the panel.
+    var onMetricsChange: (() -> Void)?
+
+    func updateMetrics(_ new: PanelMetrics) {
+        guard new != metrics else { return }
+        metrics = new
+        onMetricsChange?()
+    }
 
     /// Set by AppDelegate so the view can request a commit + window dismiss from a mouse click.
     var commitAndDismiss: (() -> Void)?

--- a/Sources/Switch/SwitchModel.swift
+++ b/Sources/Switch/SwitchModel.swift
@@ -15,6 +15,16 @@ struct PanelMetrics: Equatable {
         hintHeight = max(hintHeight, other.hintHeight)
         headerHeight = max(headerHeight, other.headerHeight)
     }
+
+    /// Zero means "not in the view right now", not "zero tall": the empty state removes
+    /// the rows, and the header only appears in some configurations. Keeping the last
+    /// real height stops those transitions from looking like a change in size.
+    mutating func mergeKnown(_ other: PanelMetrics) {
+        if other.rowHeight > 0 { rowHeight = other.rowHeight }
+        if other.tileHeight > 0 { tileHeight = other.tileHeight }
+        if other.hintHeight > 0 { hintHeight = other.hintHeight }
+        if other.headerHeight > 0 { headerHeight = other.headerHeight }
+    }
 }
 
 @MainActor
@@ -40,8 +50,10 @@ final class SwitchModel: ObservableObject {
     var onMetricsChange: (() -> Void)?
 
     func updateMetrics(_ new: PanelMetrics) {
-        guard new != metrics else { return }
-        metrics = new
+        var merged = metrics
+        merged.mergeKnown(new)
+        guard merged != metrics else { return }
+        metrics = merged
         onMetricsChange?()
     }
 

--- a/Sources/Switch/SwitchPreferences.swift
+++ b/Sources/Switch/SwitchPreferences.swift
@@ -8,6 +8,7 @@ final class SwitchPreferences: ObservableObject {
     nonisolated static let defaultThumbnailHeight = 130.0
     nonisolated static let defaultAppIconSize = 32.0
     nonisolated static let defaultGridColumns = 4
+    nonisolated static let defaultMaxListRows = 8
     nonisolated static let defaultPickerActivationDelay = 130.0
     nonisolated static let compactThumbnailHeight = 72.0
 
@@ -168,6 +169,11 @@ final class SwitchPreferences: ObservableObject {
         didSet { UserDefaults.standard.set(appIconSize, forKey: SwitchPreferences.appIconSizeKey) }
     }
 
+    /// Most rows shown at once in list view; the screen can still allow fewer.
+    @Published var maxListRows: Int {
+        didSet { UserDefaults.standard.set(maxListRows, forKey: SwitchPreferences.maxListRowsKey) }
+    }
+
     @Published var gridColumns: Int {
         didSet { UserDefaults.standard.set(gridColumns, forKey: SwitchPreferences.gridColumnsKey) }
     }
@@ -220,6 +226,7 @@ final class SwitchPreferences: ObservableObject {
     nonisolated static let thumbnailHeightKey = "switch.thumbnailHeight"
     nonisolated static let appIconSizeKey = "switch.appIconSize"
     nonisolated static let gridColumnsKey = "switch.gridColumns"
+    nonisolated static let maxListRowsKey = "switch.maxListRows"
     nonisolated static let pinnedBundleIDsKey = "switch.pinnedBundleIDs"
     nonisolated static let pickerActivationDelayKey = "switch.pickerActivationDelay"
     nonisolated static let shiftTapReversesKey = "switch.shiftTapReverses"
@@ -252,6 +259,7 @@ final class SwitchPreferences: ObservableObject {
         thumbnailHeight = (UserDefaults.standard.object(forKey: SwitchPreferences.thumbnailHeightKey) as? Double) ?? Self.defaultThumbnailHeight
         appIconSize = (UserDefaults.standard.object(forKey: SwitchPreferences.appIconSizeKey) as? Double) ?? Self.defaultAppIconSize
         gridColumns = (UserDefaults.standard.object(forKey: SwitchPreferences.gridColumnsKey) as? Int) ?? Self.defaultGridColumns
+        maxListRows = (UserDefaults.standard.object(forKey: SwitchPreferences.maxListRowsKey) as? Int) ?? Self.defaultMaxListRows
         pinnedBundleIDs = Set(UserDefaults.standard.stringArray(forKey: SwitchPreferences.pinnedBundleIDsKey) ?? [])
         pickerActivationDelay = (UserDefaults.standard.object(forKey: SwitchPreferences.pickerActivationDelayKey) as? Double) ?? Self.defaultPickerActivationDelay
         shiftTapReverses = UserDefaults.standard.bool(forKey: SwitchPreferences.shiftTapReversesKey)

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -165,6 +165,10 @@ struct SwitchView: View {
         }
         .padding(.horizontal, 22)
         .frame(height: 26)
+        // The band centers its own text, but the scroll content adds 10pt below it,
+        // so without this the header reads as pinned to the panel's top edge. This
+        // shifts the rows down with the text, so it takes the full 10pt to balance.
+        .padding(.top, 10)
         .measureHeight(into: \.headerHeight)
     }
 

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -239,7 +239,7 @@ struct SwitchView: View {
             hint(navKey, "navigate")
             if prefs.shiftTapReverses { hint("⇧", "reverse") }
             if !isSpaceMode { hint(closeKey, "close") }
-            if prefs.typeToFilter { hint("type", "filter") }
+            if filteringEnabled { hint("type", "filter") } else if !isSpaceMode { hint("⌘F", "filter") }
             hint("esc", "cancel")
             Spacer(minLength: 0)
         }
@@ -254,7 +254,12 @@ struct SwitchView: View {
     }
 
     private var closeKey: String {
-        (model.stickySession || !prefs.typeToFilter) ? "⌘W" : "⇧⌘W"
+        (model.stickySession || !filteringEnabled) ? "⌘W" : "⇧⌘W"
+    }
+
+    /// Filtering is on for this invocation, whether by preference or by ⌘F.
+    private var filteringEnabled: Bool {
+        prefs.typeToFilter || model.filterSession
     }
 
     private func stoplights(for window: WindowInfo) -> some View {

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -147,10 +147,14 @@ struct SwitchView: View {
 
     private var header: some View {
         HStack(spacing: 8) {
-            if !model.filterText.isEmpty {
+            // Shown the moment ⌘F arms filtering, so the picker acknowledges the key
+            // before there is any text to show for it.
+            if model.filterSession || !model.filterText.isEmpty {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
+            }
+            if !model.filterText.isEmpty {
                 Text(model.filterText)
                     .font(.system(size: 14, weight: .medium, design: .monospaced))
                     .foregroundStyle(.primary)

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -130,6 +130,11 @@ struct SwitchView: View {
         .offset(y: panelYOffset)
         .opacity(model.visible ? 1 : 0)
         .animation(panelAnimation, value: model.visible)
+        .onPreferenceChange(PanelMetricsKey.self) { measured in
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated { model.updateMetrics(measured) }
+            }
+        }
         .onChange(of: model.visible) { _, isVisible in
             if isVisible {
                 openMouseLocation = NSEvent.mouseLocation
@@ -160,6 +165,7 @@ struct SwitchView: View {
         }
         .padding(.horizontal, 22)
         .frame(height: 26)
+        .measureHeight(into: \.headerHeight)
     }
 
     private var grid: some View {
@@ -174,22 +180,22 @@ struct SwitchView: View {
                             LazyVStack(spacing: 4) {
                                 ForEach(Array(list.enumerated()), id: \.element.id) { idx, w in
                                     listRow(window: w, index: idx)
+                                        .measureHeight(into: \.rowHeight)
                                         .id(w.id)
                                 }
                             }
                             .padding(.horizontal, 14)
                             .padding(.top, showHeader ? 10 : 14)
-                            .padding(.bottom, 10)
                         } else {
                             LazyVGrid(columns: gridColumns, spacing: 14) {
                                 ForEach(Array(list.enumerated()), id: \.element.id) { idx, w in
                                     tile(window: w, index: idx, list: list)
+                                        .measureHeight(into: \.tileHeight)
                                         .id(w.id)
                                 }
                             }
                             .padding(.horizontal, 22)
                             .padding(.top, 4)
-                            .padding(.bottom, 12)
                         }
                     }
                     .onChange(of: model.selected) { _, new in
@@ -205,6 +211,10 @@ struct SwitchView: View {
                             proxy.scrollTo(cur[new].id, anchor: .center)
                         }
                     }
+                    // Outside the scroll content: in there it trails the last row, so it
+                    // only reaches the bottom edge once the list is scrolled to its end,
+                    // and the gap it was meant to hold renders a clipped row instead.
+                    .padding(.bottom, isSpaceMode || prefs.verticalList ? 10 : 12)
                 }
             }
         }
@@ -236,6 +246,7 @@ struct SwitchView: View {
         .padding(.horizontal, 22)
         .padding(.vertical, 8)
         .background(Color.black.opacity(0.18))
+        .measureHeight(into: \.hintHeight)
     }
 
     private var navKey: String {
@@ -523,12 +534,36 @@ private struct SelectionChrome: ViewModifier {
                 ZStack {
                     if selected {
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                            .stroke(accent.opacity(0.7), lineWidth: 1)
+                            // strokeBorder, not stroke: a centered stroke puts half its width
+                            // outside the row, which the scroll view clips off the first and
+                            // last rows once the list fills the viewport exactly.
+                            .strokeBorder(accent.opacity(0.7), lineWidth: 1)
                             .matchedGeometryEffect(id: "selectionRing", in: namespace)
                     }
                 }
             )
             .animation(selectionAnimation(.spring(response: 0.22, dampingFraction: 0.85)), value: selectedValue)
             .animation(selectionAnimation(.easeOut(duration: 0.10)), value: hovered)
+    }
+}
+
+
+private struct PanelMetricsKey: PreferenceKey {
+    static let defaultValue = PanelMetrics()
+    static func reduce(value: inout PanelMetrics, nextValue: () -> PanelMetrics) {
+        value.merge(nextValue())
+    }
+}
+
+private extension View {
+    /// Reports this view's laid-out height so the panel can size itself from it.
+    func measureHeight(into keyPath: WritableKeyPath<PanelMetrics, CGFloat>) -> some View {
+        background(
+            GeometryReader { proxy in
+                var metrics = PanelMetrics()
+                metrics[keyPath: keyPath] = proxy.size.height
+                return Color.clear.preference(key: PanelMetricsKey.self, value: metrics)
+            }
+        )
     }
 }

--- a/Sources/Switch/SwitchView.swift
+++ b/Sources/Switch/SwitchView.swift
@@ -85,7 +85,7 @@ struct SwitchView: View {
     }
 
     private var showHeader: Bool {
-        isSpaceMode || !prefs.verticalList || prefs.verticalShowHeader || !model.filterText.isEmpty
+        isSpaceMode || !prefs.verticalList || prefs.verticalShowHeader || model.filterHeaderVisible
     }
 
     private var isSpaceMode: Bool { model.mode == .spaces }


### PR DESCRIPTION
Submitted by Claude Code on behalf of @hannes-ucsc.

### The list no longer shows a sliver of an extra row

The picker used to cut off a partial row at the bottom of the list, and the selected row's outline was clipped where it met the bottom edge. The list now ends on a whole row, with even spacing above the first row and below the last one, at any icon size and with or without thumbnails, previews and the hint strip. On a display too short for the full list, it shows as many whole rows as fit rather than trimming one in half.

### The header has room above it

The filter text and window count no longer sit tight against the top edge of the picker.

### New "Rows" setting

Settings → Sizing gains a Rows slider for how many rows the list shows at once, from 4 to 20. The default is 8, matching the previous fixed behaviour. The picker resizes as you drag it, and "Reset sizing" restores it along with the other sizing options.

### ⌘F filters for one invocation

With type-to-filter switched off, ⌘F now turns it on for the open picker only, without changing the preference. The picker also stays open once you press it, so you can type without keeping the modifier held. The search glass appears the moment you press ⌘F, and the hint strip advertises ⌘F when filtering is available and switches to the type hint once it is on. Press ⌘F again to leave filtering and clear what you typed; closing the picker also ends it. If you have the header switched off, ⌘F brings it back while filtering is on so that there is somewhere to see what you are typing, and it goes away again when you leave find mode.

### Key combinations behave while filtering

Previously any ⌘ combination the picker did not recognise had its letter typed into the filter — ⌘A added an "a". Combinations now either do their job (⌘W closes the selected window, ⌘Q quits its app, ⌘H hides it, ⌘, opens settings) or nothing at all.

### The picker keeps its size while you type

Filtering down to no matches used to shrink the picker, and it stayed small even after the text matched something again. Its height is now fixed for as long as it is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns picker sizing with measured SwiftUI content, adds configurable list-row limits, and introduces invocation-scoped filtering.
- Measures headers, rows, tiles, and hints to keep list rows whole across display configurations.
- Adds a persisted Rows setting with live resizing and reset support.
- Adds ⌘F filtering sessions and prevents modified key combinations from entering filter text.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported hidden-header filtering mismatch is fixed by using the same effective header condition in rendering and panel sizing.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Sources/Switch/AppDelegate.swift | Coordinates live panel resizing and now budgets the filter-revealed header consistently with the view. |
| Sources/Switch/HotkeyManager.swift | Adds invocation-scoped ⌘F state and prevents Command or Control chords from becoming filter input. |
| Sources/Switch/SettingsView.swift | Adds the Rows slider and includes it in sizing reset behavior. |
| Sources/Switch/SwitchModel.swift | Owns filter-session visibility and measured panel metrics used by the sizing flow. |
| Sources/Switch/SwitchPreferences.swift | Persists the new maximum-list-row preference with an eight-row default. |
| Sources/Switch/SwitchView.swift | Reports rendered dimensions, presents invocation filtering state, and keeps row selection borders inside clipping bounds. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Open picker] --> B[Render SwiftUI content]
  B --> C[Measure header, rows, tiles, and hints]
  C --> D[Update panel metrics]
  D --> E[Resize panel to whole rows]
  A --> F{Type-to-filter enabled?}
  F -->|No| G[Press Command-F]
  G --> H[Enable invocation filter session]
  H --> I[Reveal filter header]
  I --> B
```
</details>

<sub>Reviews (2): Last reviewed commit: ["budget the header the filter reveals"](https://github.com/sanyam-g/switch/commit/e052030dbbe935a82c31c9144427ecc020c9b20b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58430841)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Switcher model and presentation](https://app.greptile.com/sanyamg/-/custom-context/knowledge-base/sanyam-g/switch/-/docs/switcher-model-and-presentation.md)
- Knowledge Base — [Hotkey and preferences management](https://app.greptile.com/sanyamg/-/custom-context/knowledge-base/sanyam-g/switch/-/docs/hotkey-and-preferences.md)
- Knowledge Base — [Global hotkey management](https://app.greptile.com/sanyamg/-/custom-context/knowledge-base/sanyam-g/switch/-/docs/global-hotkey-management.md)
- Knowledge Base — [Settings and preference storage](https://app.greptile.com/sanyamg/-/custom-context/knowledge-base/sanyam-g/switch/-/docs/settings-and-preference-storage.md)
</details>


<!-- /greptile_comment -->
